### PR TITLE
Only expose port 80 and use http name for service

### DIFF
--- a/charts/k8s-service/README.md
+++ b/charts/k8s-service/README.md
@@ -59,7 +59,7 @@ You can read a more detailed description of `Services` in [the official
 documentation](https://kubernetes.io/docs/concepts/services-networking/service/). Here we will cover just enough to
 understand how to access your app.
 
-By default, this Helm Chart will deploy your application container in a `Pod` that exposes ports 80 and 443. These will
+By default, this Helm Chart will deploy your application container in a `Pod` that exposes ports 80. These will
 be exposed to the Kubernetes cluster behind the `Service` resource, which exposes port 80. You can modify this behavior
 by overriding the `containerPorts` input value and the `service` input value. See the corresponding section in the
 `values.yaml` file for more details.
@@ -498,8 +498,8 @@ Controlled By:      ReplicaSet/edge-service-nginx-844c978df7
 Containers:
   nginx:
     Image:        nginx:stable
-    Ports:        80/TCP, 443/TCP
-    Host Ports:   0/TCP, 0/TCP
+    Ports:        80/TCP
+    Host Ports:   0/TCP
     Environment:  <none>
     Mounts:
       /var/run/secrets/kubernetes.io/serviceaccount from default-token-mgkr9 (ro)

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -48,16 +48,12 @@
 #   - protocol (string) (required) : The network protocol (e.g TCP or UDP) that is exposed.
 #   - disabled (bool)              : Whether or not this port is disabled. This defaults to false if unset. Provided as a
 #                                    convenience to override the default ports on the commandline. For example, to
-#                                    disable port 443, you can pass `--set containerPorts.https.disabled=true`.
+#                                    disable the default port, you can pass `--set containerPorts.https.disabled=true`.
 #
-# The default config exposes TCP port 80 and binds the name `http` to it, while also exposing TCP port 443 with the
-# bound name `https`:
+# The default config exposes TCP port 80 and binds the name `http` to it.
 containerPorts:
   http:
     port: 80
-    protocol: TCP
-  https:
-    port: 443
     protocol: TCP
 
 # livenessProbe is a map that specifies the liveness probe of the main application container. Liveness probes indicate
@@ -156,14 +152,14 @@ minPodsAvailable: 0
 #                                       key of `targetPort` to indicate which port of the container the service port
 #                                       should route to. The `targetPort` can be a name defined in `containerPorts`.
 #
-# The default config configures a Service of type ClusterIP with no annotation, and binds port 80 of the pod to port 80
-# of the service, and names the binding as `app`:
+# The default config configures a Service of type ClusterIP with no annotation, and binds port 80 of the pod to the
+# port 80 of the service, and names the binding as `app`:
 service:
   enabled: true
   ports:
     app:
       port: 80
-      targetPort: 80
+      targetPort: http
       protocol: TCP
 
 # ingress is a map that can be used to configure an Ingress resource for this service. By default, turn off ingress.

--- a/examples/k8s-service-nginx/README.md
+++ b/examples/k8s-service-nginx/README.md
@@ -176,8 +176,6 @@ Get the application URL by running these commands:
   export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=nginx,app.kubernetes.io/instance=queenly-liger" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application container serving port http"
   kubectl port-forward $POD_NAME 8080:80
-  echo "Visit http://127.0.0.1:80443 to use your application container serving port https"
-  kubectl port-forward $POD_NAME 80443:443
 ```
 
 The install command will always output:
@@ -261,7 +259,7 @@ queenly-liger-nginx-7b7bb49d-zxpcm   1/1       Running   0          13m
 Here you can see that there are 3 `Pods` in the `READY` state that match that criteria. Pick one of them to access from
 the list above and record the name.
 
-Next, we need to see what ports are open on the `Pod`. The `k8s-service` Helm Chart will open ports 80 and 443 to the
+Next, we need to see what ports are open on the `Pod`. The `k8s-service` Helm Chart will open ports 80 to the
 container by default. However, if you do not know which ports are open, you can inspect the `Pod` to a list of the open
 ports. To get detailed information about a `Pod`, use `kubectl describe pod NAME`. In our example, we will pull detailed
 information about the `Pod` `queenly-liger-nginx-7b7bb49d-b8tf8`:
@@ -286,8 +284,8 @@ Containers:
     Container ID:   docker://ac921c94c8d5f9428815d64bfa541f0481ab37ddaf42a37f2ebec95eb61ef2c0
     Image:          nginx:1.14.2
     Image ID:       docker-pullable://nginx@sha256:d1eed840d5b357b897a872d17cdaa8a4fc8e6eb43faa8ad2febb31ce0c537910
-    Ports:          80/TCP, 443/TCP
-    Host Ports:     0/TCP, 0/TCP
+    Ports:          80/TCP
+    Host Ports:     0/TCP
     State:          Running
       Started:      Sat, 16 Feb 2019 09:15:09 -0800
     Ready:          True
@@ -328,10 +326,10 @@ related to the `Pod`. In the output, the `Containers` section shows addtional in
 ```
 Containers:
   nginx:
-    Ports:          80/TCP, 443/TCP
+    Ports:          80/TCP
 ```
 
-In the output, we confirm that indeed both ports 80 and 443 are open. So let's open a port forward!
+In the output, we confirm that indeed port 80 is open. So let's open a port forward!
 
 In this example, we will open a tunnel from port 8080 on our local machine to port 80 of the `Pod`:
 


### PR DESCRIPTION
__merges into https://github.com/gruntwork-io/helm-kubernetes-services/pull/7__

This updates the chart so that we only expose one port by default (80), and makes it easier to update that port. Specifically, now if you need to expose port 3000 instead you only need to set `containerPorts.http.port = 3000`. You do not need to touch the `service` input.