### PR TITLE
Fix Ingress bugs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 defaults: &defaults
-  machine: true
+  machine:
+    enabled: true
+    image: "ubuntu-1604:201903-01"
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.21
     TERRATEST_LOG_PARSER_VERSION: v0.13.13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,10 @@ deploy_tiller: &deploy_tiller
 setup_minikube: &setup_minikube
   name: install kubectl and minikube
   command: |
+    # Issues using addons with minikube due to hostpath failure
+    # See: https://github.com/kubernetes/kubernetes/issues/61058
+    mount --make-rshared /
+
     # install kubectl
     curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
     chmod +x kubectl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,12 +77,29 @@ setup_minikube: &setup_minikube
 
     # This installs nginx ingress controller
     sudo -E minikube addons enable ingress
+
+    # Now we need to wait for the nginx-ingress-controller deployment to be created
+    $(
+      # Wait for deployment to show up
+      for i in {1..150}; do # timeout for 5 minutes
+        kubectl get deployment -n kube-system nginx-ingress-controller &> /dev/null
+        if [ $? -ne 1 ]; then
+          break
+        fi
+        sleep 2
+      done
+      true
+    )
+
     # Next, we need to patch it so it exposes the nginx controller on the host network so that we get a valid endpoint to
     # access it.
-    kubectl patch deployment -n ingress-nginx nginx-ingress-controller --patch "spec:
+    kubectl patch deployment -n kube-system nginx-ingress-controller --patch "spec:
       template:
         spec:
           hostNetwork: true"
+
+    # Finally we wait for the rollout
+    kubectl rollout status -n kube-system deployment/nginx-ingress-controller --watch
 
 
 install_gruntwork_utils: &install_gruntwork_utils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,7 @@ defaults: &defaults
     TERRAGRUNT_VERSION: NONE
     PACKER_VERSION: NONE
     GOLANG_VERSION: 1.11.2
-    K8S_VERSION: v1.10.0  # Same as EKS
     KUBECONFIG: /home/circleci/.kube/config
-    MINIKUBE_VERSION: v1.0.0
-    MINIKUBE_WANTUPDATENOTIFICATION: "false"
-    MINIKUBE_WANTREPORTERRORPROMPT: "false"
-    MINIKUBE_HOME: /home/circleci
-    CHANGE_MINIKUBE_NONE_USER: "true"
 
 
 install_helm_client: &install_helm_client
@@ -30,85 +24,12 @@ install_helm_client: &install_helm_client
     sudo mv linux-amd64/helm /usr/local/bin/
 
 
-# Install and setup minikube
-# https://github.com/kubernetes/minikube#linux-continuous-integration-without-vm-support
-setup_minikube: &setup_minikube
-  name: install kubectl and minikube
-  command: |
-    # Install yq so we can modify the configmap
-    sudo add-apt-repository ppa:rmescandon/yq
-    sudo apt-get update
-    sudo apt install -y yq
-
-    # Issues using addons with minikube due to hostpath failure
-    # See: https://github.com/kubernetes/kubernetes/issues/61058
-    sudo mount --make-rshared /
-
-    # install kubectl
-    curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
-    chmod +x kubectl
-    sudo mv kubectl /usr/local/bin/
-    mkdir -p ${HOME}/.kube
-    touch ${HOME}/.kube/config
-
-    # Install minikube
-    curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/${MINIKUBE_VERSION}/minikube-linux-amd64
-    chmod +x minikube
-    sudo mv minikube /usr/local/bin/
-
-    # start minikube and wait for it
-    sudo -E minikube start \
-      --vm-driver=none \
-      --kubernetes-version=${K8S_VERSION} \
-      --extra-config=apiserver.Authorization.Mode=RBAC \
-      --cpus 2 --memory 4096
-
-    # this for loop waits until kubectl can access the api server that Minikube has created
-    $(
-      for i in {1..150}; do # timeout for 5 minutes
-        kubectl get po &> /dev/null
-        if [ $? -ne 1 ]; then
-          break
-        fi
-        sleep 2
-      done
-      true
-    )
-
-    # Disable some addons we don't need
-    sudo -E minikube addons disable dashboard
-
-    # This installs nginx ingress controller
-    sudo -E minikube addons enable ingress
-
-    # Now we need to wait for the nginx-ingress-controller deployment to be created
-    $(
-      # Wait for deployment to show up
-      for i in {1..150}; do # timeout for 5 minutes
-        kubectl get deployment -n kube-system nginx-ingress-controller &> /dev/null
-        if [ $? -ne 1 ]; then
-          break
-        fi
-        sleep 2
-      done
-      true
-    )
-
-    # Make sure to grant the default service account cluster admin rights so helm and ingress controller works
-    kubectl create clusterrolebinding default-service-account-cluster-admin-binding --clusterrole cluster-admin --serviceaccount kube-system:default
-
-    # Update the configmap to disable SSL since we won't have certs
-    kubectl get configmap -n kube-system nginx-load-balancer-conf -o yaml | yq write - data.ssl-redirect "\"false\"" | kubectl replace -f -
-
-    # Finally we wait for the rollout
-    kubectl rollout status -n kube-system deployment/nginx-ingress-controller --watch
-
-
 install_gruntwork_utils: &install_gruntwork_utils
   name: install gruntwork utils
   command: |
     curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
     gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
+    gruntwork-install --module-name "kubernetes-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --branch yori-add-k8s
     gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
     configure-environment-for-gruntwork-module \
       --circle-ci-2-machine-executor \
@@ -163,7 +84,7 @@ jobs:
           <<: *install_gruntwork_utils
 
       - run:
-          <<: *setup_minikube
+          command: setup-minikube
 
       - run:
           <<: *install_helm_client

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,12 +75,10 @@ setup_minikube: &setup_minikube
     sudo -E minikube addons enable ingress
     # Next, we need to patch it so it exposes the nginx controller on the host network so that we get a valid endpoint to
     # access it.
-    kubectl patch deployment -n ingress-nginx nginx-ingress-controller --patch << EOF
-    spec:
+    kubectl patch deployment -n ingress-nginx nginx-ingress-controller --patch "spec:
       template:
         spec:
-          hostNetwork: true
-    EOF
+          hostNetwork: true"
 
 
 install_gruntwork_utils: &install_gruntwork_utils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,15 +28,6 @@ install_helm_client: &install_helm_client
     sudo mv linux-amd64/helm /usr/local/bin/
 
 
-deploy_tiller: &deploy_tiller
-  name: deploy tiller
-  command: |
-    # Grant the default service account cluster admin rights so helm works
-    kubectl create clusterrolebinding default-service-account-cluster-admin-binding --clusterrole cluster-admin --serviceaccount kube-system:default
-    # Deploy Tiller
-    helm init --wait
-
-
 # Install and setup minikube
 # https://github.com/kubernetes/minikube#linux-continuous-integration-without-vm-support
 setup_minikube: &setup_minikube
@@ -74,6 +65,9 @@ setup_minikube: &setup_minikube
       done
       true
     )
+
+    # Grant the default service account cluster admin rights so helm and ingress controller works
+    kubectl create clusterrolebinding default-service-account-cluster-admin-binding --clusterrole cluster-admin --serviceaccount kube-system:default
 
     # This installs nginx ingress controller
     sudo -E minikube addons enable ingress
@@ -167,7 +161,8 @@ jobs:
           <<: *install_helm_client
 
       - run:
-          <<: *deploy_tiller
+          name: deploy tiller
+          command: helm init --wait
 
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ install_gruntwork_utils: &install_gruntwork_utils
   command: |
     curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
     gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
-    gruntwork-install --module-name "kubernetes-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --branch yori-localkube
+    gruntwork-install --module-name "kubernetes-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --branch yori-add-k8s
     gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
     configure-environment-for-gruntwork-module \
       --circle-ci-2-machine-executor \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,9 @@ setup_minikube: &setup_minikube
   name: install kubectl and minikube
   command: |
     # Install yq so we can modify the configmap
-    sudo apt-get update && sudo apt-get install -y yq
+    sudo add-apt-repository ppa:rmescandon/yq
+    sudo apt-get update
+    sudo apt install -y yq
 
     # Issues using addons with minikube due to hostpath failure
     # See: https://github.com/kubernetes/kubernetes/issues/61058

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ install_gruntwork_utils: &install_gruntwork_utils
   command: |
     curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
     gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
-    gruntwork-install --module-name "kubernetes-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --branch yori-add-k8s
+    gruntwork-install --module-name "kubernetes-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --branch yori-localkube
     gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
     configure-environment-for-gruntwork-module \
       --circle-ci-2-machine-executor \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ setup_minikube: &setup_minikube
   command: |
     # Issues using addons with minikube due to hostpath failure
     # See: https://github.com/kubernetes/kubernetes/issues/61058
-    mount --make-rshared /
+    sudo mount --make-rshared /
 
     # install kubectl
     curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
     GRUNTWORK_INSTALLER_VERSION: v0.0.21
     TERRATEST_LOG_PARSER_VERSION: v0.13.13
     HELM_VERSION: v2.12.2
-    MODULE_CI_VERSION: v0.13.3
+    MODULE_CI_VERSION: v0.13.12
     TERRAFORM_VERSION: NONE
     TERRAGRUNT_VERSION: NONE
     PACKER_VERSION: NONE
@@ -29,7 +29,7 @@ install_gruntwork_utils: &install_gruntwork_utils
   command: |
     curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
     gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
-    gruntwork-install --module-name "kubernetes-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --branch yori-add-k8s
+    gruntwork-install --module-name "kubernetes-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
     gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
     configure-environment-for-gruntwork-module \
       --circle-ci-2-machine-executor \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,13 +85,6 @@ setup_minikube: &setup_minikube
     # Make sure to grant the default service account cluster admin rights so helm and ingress controller works
     kubectl create clusterrolebinding default-service-account-cluster-admin-binding --clusterrole cluster-admin --serviceaccount kube-system:default
 
-    # Next, we need to patch it so it exposes the nginx controller on the host network so that we get a valid endpoint to
-    # access it.
-    kubectl patch deployment -n kube-system nginx-ingress-controller --patch "spec:
-      template:
-        spec:
-          hostNetwork: true"
-
     # Finally we wait for the rollout
     kubectl rollout status -n kube-system deployment/nginx-ingress-controller --watch
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,15 @@ setup_minikube: &setup_minikube
     )
 
     # This installs nginx ingress controller
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/mandatory.yaml
     sudo -E minikube addons enable ingress
+    # Next, we need to patch it so it exposes the nginx controller on the host network so that we get a valid endpoint to
+    # access it.
+    kubectl patch deployment -n ingress-nginx nginx-ingress-controller --patch << EOF
+    spec:
+      template:
+        spec:
+          hostNetwork: true
+    EOF
 
 
 install_gruntwork_utils: &install_gruntwork_utils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,9 @@ setup_minikube: &setup_minikube
       true
     )
 
+    # Disable some addons we don't need
+    sudo -E minikube addons disable dashboard
+
     # This installs nginx ingress controller
     sudo -E minikube addons enable ingress
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ install_helm_client: &install_helm_client
 setup_minikube: &setup_minikube
   name: install kubectl and minikube
   command: |
+    # Install yq so we can modify the configmap
+    sudo apt-get update && sudo apt-get install -y yq
+
     # Issues using addons with minikube due to hostpath failure
     # See: https://github.com/kubernetes/kubernetes/issues/61058
     sudo mount --make-rshared /
@@ -95,6 +98,9 @@ setup_minikube: &setup_minikube
 
     # Make sure to grant the default service account cluster admin rights so helm and ingress controller works
     kubectl create clusterrolebinding default-service-account-cluster-admin-binding --clusterrole cluster-admin --serviceaccount kube-system:default
+
+    # Update the configmap to disable SSL since we won't have certs
+    kubectl get configmap -n kube-system nginx-load-balancer-conf -o yaml | yq write - data.ssl-redirect "\"false\"" | kubectl replace -f -
 
     # Finally we wait for the rollout
     kubectl rollout status -n kube-system deployment/nginx-ingress-controller --watch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ defaults: &defaults
     GOLANG_VERSION: 1.11.2
     K8S_VERSION: v1.10.0  # Same as EKS
     KUBECONFIG: /home/circleci/.kube/config
-    MINIKUBE_VERSION: v0.28.2  # See https://github.com/kubernetes/minikube/issues/2704
+    MINIKUBE_VERSION: v1.0.0
     MINIKUBE_WANTUPDATENOTIFICATION: "false"
     MINIKUBE_WANTREPORTERRORPROMPT: "false"
     MINIKUBE_HOME: /home/circleci
@@ -57,13 +57,9 @@ setup_minikube: &setup_minikube
     sudo mv minikube /usr/local/bin/
 
     # start minikube and wait for it
-    # Ignore warnings on minikube start command, as it will log a warning due to using deprecated localkube
-    # bootstrapper. However, the localkube bootstrapper is necessary to run on CircleCI which doesn't have
-    # systemd.
     sudo -E minikube start \
       --vm-driver=none \
       --kubernetes-version=${K8S_VERSION} \
-      --bootstrapper=localkube \
       --extra-config=apiserver.Authorization.Mode=RBAC \
       --cpus 2 --memory 4096
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,9 @@ setup_minikube: &setup_minikube
       true
     )
 
+    # This installs nginx ingress controller
+    sudo -E minikube addons enable ingress
+
 
 install_gruntwork_utils: &install_gruntwork_utils
   name: install gruntwork utils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,9 +66,6 @@ setup_minikube: &setup_minikube
       true
     )
 
-    # Grant the default service account cluster admin rights so helm and ingress controller works
-    kubectl create clusterrolebinding default-service-account-cluster-admin-binding --clusterrole cluster-admin --serviceaccount kube-system:default
-
     # This installs nginx ingress controller
     sudo -E minikube addons enable ingress
 
@@ -84,6 +81,9 @@ setup_minikube: &setup_minikube
       done
       true
     )
+
+    # Make sure to grant the default service account cluster admin rights so helm and ingress controller works
+    kubectl create clusterrolebinding default-service-account-cluster-admin-binding --clusterrole cluster-admin --serviceaccount kube-system:default
 
     # Next, we need to patch it so it exposes the nginx controller on the host network so that we get a valid endpoint to
     # access it.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ setup_minikube: &setup_minikube
     )
 
     # This installs nginx ingress controller
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/mandatory.yaml
     sudo -E minikube addons enable ingress
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,13 @@ setup_minikube: &setup_minikube
     # Ignore warnings on minikube start command, as it will log a warning due to using deprecated localkube
     # bootstrapper. However, the localkube bootstrapper is necessary to run on CircleCI which doesn't have
     # systemd.
-    sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION} --bootstrapper=localkube --extra-config=apiserver.Authorization.Mode=RBAC
+    sudo -E minikube start \
+      --vm-driver=none \
+      --kubernetes-version=${K8S_VERSION} \
+      --bootstrapper=localkube \
+      --extra-config=apiserver.Authorization.Mode=RBAC \
+      --cpus 2 --memory 4096
+
     # this for loop waits until kubectl can access the api server that Minikube has created
     $(
       for i in {1..150}; do # timeout for 5 minutes

--- a/charts/k8s-service/templates/ingress.yaml
+++ b/charts/k8s-service/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     helm.sh/chart: {{ include "k8s-service.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- if .Values.service.annotations }}
+{{- if .Values.ingress.annotations }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/k8s-service/templates/ingress.yaml
+++ b/charts/k8s-service/templates/ingress.yaml
@@ -10,7 +10,7 @@ We declare some variables defined on the Values. These are reused in `with` and 
 {{- $fullName := include "k8s-service.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $servicePort := .Values.ingress.servicePort -}}
-apiVersion: extensions/v1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/k8s-service/templates/ingress.yaml
+++ b/charts/k8s-service/templates/ingress.yaml
@@ -36,6 +36,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{- if .Values.ingress.hosts }}
     {{- range .Values.ingress.hosts }}
     - host: {{ . | quote }}
       http:
@@ -44,5 +45,14 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
+    {{- end }}
+    {{- else }}
+    - http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+
     {{- end }}
 {{- end }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -172,8 +172,8 @@ service:
 #   - tls         (list[map])               : Sets up TLS termination on the ingress rule. Each item is a separate TLS
 #                                             rule that maps to one or more hosts specified in this ingress rule. This
 #                                             is injected directly in to the resource yaml.
-#   - hosts       (list[string]) (required) : Sets up the host routes for the ingress resource. There will be a routing
-#                                             rule for each host defined in this list.
+#   - hosts       (list[string])            : Sets up the host routes for the ingress resource. There will be a routing
+#                                             rule for each host defined in this list. If empty, will match all hosts.
 #   - path        (string)       (required) : The url path to match to route to the Service.
 #   - servicePort (int|string)   (required) : The port (as a number) or the name of the port on the Service to route to.
 #

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -214,7 +214,6 @@
   version = "v0.4.2"
 
 [[projects]]
-  branch = "yori-k8s-ingress-functions"
   digest = "1:a10f2c49a4cdae2bfa8baff73872d3ac8163749a627d06746f9f373a0d7f4ad5"
   name = "github.com/gruntwork-io/terratest"
   packages = [
@@ -233,7 +232,8 @@
     "modules/ssh",
   ]
   pruneopts = "UT"
-  revision = "c6e25bd863c495d47592577bb919cebe00f1e0cb"
+  revision = "c3e1e0ab1e41a00e6c27d56216435f4b4c7311a3"
+  version = "v0.14.5"
 
 [[projects]]
   digest = "1:a0cefd27d12712af4b5018dc7046f245e1e3b5760e2e848c30b171b570708f9b"
@@ -658,13 +658,11 @@
     "github.com/gruntwork-io/terratest/modules/k8s",
     "github.com/gruntwork-io/terratest/modules/logger",
     "github.com/gruntwork-io/terratest/modules/random",
-    "github.com/gruntwork-io/terratest/modules/retry",
     "github.com/gruntwork-io/terratest/modules/shell",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
-    "k8s.io/api/extensions/v1beta1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
   ]
   solver-name = "gps-cdcl"

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -10,7 +10,7 @@
   version = "v0.36.0"
 
 [[projects]]
-  digest = "1:f558d34644aea9acaaaa049c636cd613df451d5ca179949bc583bfda80ca6975"
+  digest = "1:2d440c27c25ac4569edb21b27d5cfcbeb383382d3384d7691347377fbfa1f9f6"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -52,6 +52,7 @@
     "service/autoscaling",
     "service/cloudwatchlogs",
     "service/ec2",
+    "service/ecs",
     "service/iam",
     "service/kms",
     "service/rds",
@@ -213,7 +214,8 @@
   version = "v0.4.2"
 
 [[projects]]
-  digest = "1:1028a3022d92b62fb4efb3216503834ebbeb38144d7ffdf4c4ee4acb0f069e35"
+  branch = "yori-k8s-ingress-functions"
+  digest = "1:a10f2c49a4cdae2bfa8baff73872d3ac8163749a627d06746f9f373a0d7f4ad5"
   name = "github.com/gruntwork-io/terratest"
   packages = [
     "modules/aws",
@@ -231,8 +233,7 @@
     "modules/ssh",
   ]
   pruneopts = "UT"
-  revision = "b6077c8c1ecfd290ee1f37e1e51472a34d30cb38"
-  version = "v0.13.29"
+  revision = "c6e25bd863c495d47592577bb919cebe00f1e0cb"
 
 [[projects]]
   digest = "1:a0cefd27d12712af4b5018dc7046f245e1e3b5760e2e848c30b171b570708f9b"
@@ -655,11 +656,15 @@
     "github.com/gruntwork-io/terratest/modules/helm",
     "github.com/gruntwork-io/terratest/modules/http-helper",
     "github.com/gruntwork-io/terratest/modules/k8s",
+    "github.com/gruntwork-io/terratest/modules/logger",
     "github.com/gruntwork-io/terratest/modules/random",
+    "github.com/gruntwork-io/terratest/modules/retry",
+    "github.com/gruntwork-io/terratest/modules/shell",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
+    "k8s.io/api/extensions/v1beta1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
   ]
   solver-name = "gps-cdcl"

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -27,7 +27,8 @@
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"
-  version = "0.13.28"
+  # TODO: use released version when PR merges
+  branch = "yori-k8s-ingress-functions"
 
 [prune]
   go-tests = true

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -27,8 +27,7 @@
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"
-  # TODO: use released version when PR merges
-  branch = "yori-k8s-ingress-functions"
+  version = "0.14.5"
 
 [prune]
   go-tests = true

--- a/test/k8s_service_example_test_helpers.go
+++ b/test/k8s_service_example_test_helpers.go
@@ -104,7 +104,7 @@ func verifyServiceAvailable(
 	// Now hit the service endpoint to verify it is accessible
 	// Refresh service object in memory
 	service = *k8s.GetService(t, kubectlOptions, service.Name)
-	serviceEndpoint := k8s.GetServiceEndpoint(t, &service, 80)
+	serviceEndpoint := k8s.GetServiceEndpoint(t, kubectlOptions, &service, 80)
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
 		fmt.Sprintf("http://%s", serviceEndpoint),

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -12,9 +12,12 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Test that:
@@ -22,7 +25,8 @@ import (
 // 1. We can deploy the example
 // 2. The deployment succeeds without errors
 // 3. We can open a port forward to one of the Pods and access nginx
-// 4. We can access ngix via the service endpoint
+// 4. We can access nginx via the service endpoint
+// 5. We can access nginx via the ingress endpoint
 func TestK8SServiceNginxExample(t *testing.T) {
 	t.Parallel()
 
@@ -45,6 +49,12 @@ func TestK8SServiceNginxExample(t *testing.T) {
 	options := &helm.Options{
 		KubectlOptions: kubectlOptions,
 		ValuesFiles:    []string{filepath.Join(examplePath, "values.yaml")},
+		SetValues: map[string]string{
+			"ingress.enabled":     "true",
+			"ingress.path":        "/app",
+			"ingress.servicePort": "http",
+			"ingress.annotations.\"kubernetes\\.io/ingress\\.class\"": "nginx",
+		},
 	}
 	defer helm.Delete(t, options, releaseName, true)
 	helm.Install(t, options, helmChartPath, releaseName)
@@ -52,9 +62,45 @@ func TestK8SServiceNginxExample(t *testing.T) {
 	verifyPodsCreatedSuccessfully(t, kubectlOptions, "nginx", releaseName)
 	verifyAllPodsAvailable(t, kubectlOptions, "nginx", releaseName, nginxValidationFunction)
 	verifyServiceAvailable(t, kubectlOptions, "nginx", releaseName, nginxValidationFunction)
+	verifyIngressAvailable(t, kubectlOptions, "nginx", releaseName, nginxValidationFunction)
 }
 
 // nginxValidationFunction checks that we get a 200 response with the nginx welcome page.
 func nginxValidationFunction(statusCode int, body string) bool {
 	return statusCode == 200 && strings.Contains(body, "Welcome to nginx")
+}
+
+func verifyIngressAvailable(
+	t *testing.T,
+	kubectlOptions *k8s.KubectlOptions,
+	appName string,
+	releaseName string,
+	validationFunction func(int, string) bool,
+) {
+	// Get the service and wait until it is available
+	filters := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s,app.kubernetes.io/instance=%s", appName, releaseName),
+	}
+	ingresses := listIngress(t, kubectlOptions, filters)
+	require.Equal(t, len(ingresses), 1)
+	ingress := ingresses[0]
+
+	// Now hit the service endpoint to verify it is accessible
+	ingressEndpoint := ingress.Status.LoadBalancer.Ingress[0].IP
+	http_helper.HttpGetWithRetryWithCustomValidation(
+		t,
+		fmt.Sprintf("http://%s", ingressEndpoint),
+		WaitTimerRetries,
+		WaitTimerSleep,
+		validationFunction,
+	)
+
+}
+
+func listIngress(t *testing.T, options *k8s.KubectlOptions, filters metav1.ListOptions) []extensionsv1beta1.Ingress {
+	clientset, err := k8s.GetKubernetesClientFromOptionsE(t, options)
+	require.NoError(t, err)
+	resp, err := clientset.ExtensionsV1beta1().Ingresses(options.Namespace).List(filters)
+	require.NoError(t, err)
+	return resp.Items
 }

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -56,8 +56,8 @@ func TestK8SServiceNginxExample(t *testing.T) {
 			"ingress.enabled":     "true",
 			"ingress.path":        "/app",
 			"ingress.servicePort": "http",
-			"ingress.annotations.\"kubernetes\\.io/ingress\\.class\"":        "nginx",
-			"ingress.annotations.\"ingress\\.kubernetes\\.io/ssl-redirect\"": "false",
+			"ingress.annotations.\"kubernetes\\.io/ingress\\.class\"":                "nginx",
+			"ingress.annotations.\"nginx\\.ingress\\.kubernetes\\.io/ssl-redirect\"": "false",
 		},
 	}
 	defer helm.Delete(t, options, releaseName, true)

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/stretchr/testify/require"

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -137,6 +137,7 @@ func waitUntilIngressAvailable(t *testing.T, options *k8s.KubectlOptions, ingres
 			if err != nil {
 				return "", err
 			}
+			logger.Logf(t, "wtf %v", ingress)
 			if len(ingress.Status.LoadBalancer.Ingress) == 0 {
 				return "", fmt.Errorf("Ingress not available")
 			}

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -137,7 +137,6 @@ func waitUntilIngressAvailable(t *testing.T, options *k8s.KubectlOptions, ingres
 			if err != nil {
 				return "", err
 			}
-			logger.Logf(t, "wtf %v", ingress)
 			if len(ingress.Status.LoadBalancer.Ingress) == 0 {
 				return "", fmt.Errorf("Ingress not available")
 			}

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -56,8 +56,9 @@ func TestK8SServiceNginxExample(t *testing.T) {
 			"ingress.enabled":     "true",
 			"ingress.path":        "/app",
 			"ingress.servicePort": "http",
-			"ingress.annotations.\"kubernetes\\.io/ingress\\.class\"":                "nginx",
-			"ingress.annotations.\"nginx\\.ingress\\.kubernetes\\.io/ssl-redirect\"": "false",
+			"ingress.annotations.\"kubernetes\\.io/ingress\\.class\"":                  "nginx",
+			"ingress.annotations.\"nginx\\.ingress\\.kubernetes\\.io/rewrite-target\"": "/",
+			"ingress.annotations.\"nginx\\.ingress\\.kubernetes\\.io/ssl-redirect\"":   "\"false\"",
 		},
 	}
 	defer helm.Delete(t, options, releaseName, true)

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -85,17 +85,17 @@ func verifyIngressAvailable(
 	}
 	ingresses := listIngress(t, kubectlOptions, filters)
 	require.Equal(t, len(ingresses), 1)
-	ingress := ingresses[0]
+	ingressName := ingresses[0].Name
 	waitUntilIngressAvailable(
 		t,
 		kubectlOptions,
-		ingress.Name,
+		ingressName,
 		WaitTimerRetries,
 		WaitTimerSleep,
 	)
 
 	// Now hit the service endpoint to verify it is accessible
-	ingress, err := getIngressE(t, kubectlOptions, ingress.Name)
+	ingress, err := getIngressE(t, kubectlOptions, ingressName)
 	require.NoError(t, err)
 	ingressEndpoint := ingress.Status.LoadBalancer.Ingress[0].IP
 	http_helper.HttpGetWithRetryWithCustomValidation(

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -10,11 +10,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/stretchr/testify/require"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -133,9 +135,6 @@ func waitUntilIngressAvailable(t *testing.T, options *k8s.KubectlOptions, ingres
 			ingress, err := getIngressE(t, options, ingressName)
 			if err != nil {
 				return "", err
-			}
-			if ingress.Status.LoadBalancer == nil {
-				return "", fmt.Errorf("Ingress not available")
 			}
 			if len(ingress.Status.LoadBalancer.Ingress) == 0 {
 				return "", fmt.Errorf("Ingress not available")

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -56,9 +56,9 @@ func TestK8SServiceNginxExample(t *testing.T) {
 			"ingress.enabled":     "true",
 			"ingress.path":        "/app",
 			"ingress.servicePort": "http",
-			"ingress.annotations.\"kubernetes\\.io/ingress\\.class\"":                  "nginx",
-			"ingress.annotations.\"nginx\\.ingress\\.kubernetes\\.io/rewrite-target\"": "/",
-			"ingress.annotations.\"nginx\\.ingress\\.kubernetes\\.io/ssl-redirect\"":   "\"false\"",
+			"ingress.annotations.kubernetes\\.io/ingress\\.class":                  "nginx",
+			"ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/rewrite-target": "/",
+			"ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/ssl-redirect":   "\"false\"",
 		},
 	}
 	defer helm.Delete(t, options, releaseName, true)

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -56,7 +56,8 @@ func TestK8SServiceNginxExample(t *testing.T) {
 			"ingress.enabled":     "true",
 			"ingress.path":        "/app",
 			"ingress.servicePort": "http",
-			"ingress.annotations.\"kubernetes\\.io/ingress\\.class\"": "nginx",
+			"ingress.annotations.\"kubernetes\\.io/ingress\\.class\"":        "nginx",
+			"ingress.annotations.\"ingress\\.kubernetes\\.io/ssl-redirect\"": "false",
 		},
 	}
 	defer helm.Delete(t, options, releaseName, true)
@@ -101,7 +102,7 @@ func verifyIngressAvailable(
 	ingressEndpoint := ingress.Status.LoadBalancer.Ingress[0].IP
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
-		fmt.Sprintf("http://%s", ingressEndpoint),
+		fmt.Sprintf("http://%s/app", ingressEndpoint),
 		WaitTimerRetries,
 		WaitTimerSleep,
 		validationFunction,

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -10,16 +10,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/stretchr/testify/require"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -58,7 +58,6 @@ func TestK8SServiceNginxExample(t *testing.T) {
 			"ingress.servicePort": "http",
 			"ingress.annotations.kubernetes\\.io/ingress\\.class":                  "nginx",
 			"ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/rewrite-target": "/",
-			"ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/ssl-redirect":   "\"false\"",
 		},
 	}
 	defer helm.Delete(t, options, releaseName, true)


### PR DESCRIPTION
__~This depends on https://github.com/gruntwork-io/terratest/pull/273 and https://github.com/gruntwork-io/module-ci/pull/91~ Both are merged and PR is updated to point to released versions__

This fixes several bugs found in the `Ingress` resource template:

- The API group is `extensions/v1beta1`.
- There was a typo in one of the if conditions.
- The rules required setting a `host`, but sometimes you want the ingress to match all hosts. This supports that.

To flush these bugs out, I implemented a test that verifies that the chart correctly provisions an ingress resource and that you can access a service using the ingress endpoint.