### PR TITLE
Support image pull secrets

### DIFF
--- a/charts/k8s-service/README.md
+++ b/charts/k8s-service/README.md
@@ -949,3 +949,35 @@ In this config, the side car containers are rendered as additional containers to
 container configured by the `containerImage`, `ports`, `livenessProbe`, etc input values. Note that the
 `sideCarContainers` variable directly renders the spec, meaning that the additional values for the side cars such as
 `livenessProbe` should be rendered directly within the `sideCarContainers` input value.
+
+
+## How do I use a private registry?
+
+To pull container images from a private registry, the Kubernetes cluster needs to be able to authenticate to the docker
+registry with a registry key. On managed Kubernetes clusters (e.g EKS, GKE, AKS), this is automated through the server
+IAM roles that are assigned to the instance VMs. In most cases, if the instance VM IAM role has the permissions to
+access the registry, the Kubernetes cluster will automatically be able to pull down images from the respective managed
+registry (e.g ECR on EKS or GCR on GKE).
+
+Alternatively, you can specify docker registry keys in the Kubernetes cluster as `Secret` resources. This is helpful in
+situations where you do not have the ability to assign registry access IAM roles to the node itself, or if you are
+pulling images off of a different registry (e.g accessing GCR from EKS cluster).
+
+You can use `kubectl` to create a `Secret` in Kubernetes that can be used as a docker registry key:
+
+```
+kubectl create secret docker-registry NAME \
+  --docker-server=DOCKER_REGISTRY_SERVER \
+  --docker-username=DOCKER_USER \
+  --docker-password=DOCKER_PASSWORD \
+  --docker-email=DOCKER_EMAIL
+```
+
+This command will create a `Secret` resource named `NAME` that holds the specified docker registry credentials. You can
+then specify the cluster to use this `Secret` when pulling down images for the service `Deployment` in this chart by
+using the `imagePullSecrets` input value:
+
+```
+imagePullSecrets:
+  - NAME
+```

--- a/charts/k8s-service/README.md
+++ b/charts/k8s-service/README.md
@@ -981,3 +981,6 @@ using the `imagePullSecrets` input value:
 imagePullSecrets:
   - NAME
 ```
+
+You can learn more about using private registries with Kubernetes in [the official
+documentation](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry).

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -206,6 +206,15 @@ spec:
 {{ toYaml $value | indent 12 }}
         {{- end }}
 
+    {{- /* START IMAGE PULL SECRETS LOGIC */ -}}
+    {{- if gt (len .Values.imagePullSecrets) 0 }}
+      imagePullSecrets:
+        {{- range $secretName := .Values.imagePullSecrets }}
+        - name: {{ $secretName }}
+        {{- end }}
+    {{- end }}
+    {{- /* END IMAGE PULL SECRETS LOGIC */ -}}
+
     {{- /* START VOLUME LOGIC */ -}}
     {{- if index $hasInjectionTypes "hasVolume" }}
       volumes:
@@ -245,7 +254,7 @@ spec:
       {{- end }}
     {{- end }}
     {{- /* END VOLUME LOGIC */ -}}
-    
+
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -322,3 +322,7 @@ affinity: {}
 # NOTE: This variable is injected directly into the pod spec. See the official documentation for what this might look
 # like: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
+
+# imagePullSecrets lists the Secret resources that should be used for accessing private registries. Each item in the
+# list is a string that corresponds to the Secret name.
+imagePullSecrets: []


### PR DESCRIPTION
This adds support for rendering in `imagePullSecrets` to the pod spec of the deployment so that we can support private registries.

See https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry for more info