### PR TITLE
Enable setting additional paths on ingress

### DIFF
--- a/charts/k8s-service/templates/ingress.yaml
+++ b/charts/k8s-service/templates/ingress.yaml
@@ -9,6 +9,8 @@ We declare some variables defined on the Values. These are reused in `with` and 
 */ -}}
 {{- $fullName := include "k8s-service.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $additionalPathsHigherPriority := .Values.ingress.additionalPathsHigherPriority }}
+{{- $additionalPaths := .Values.ingress.additionalPaths }}
 {{- $servicePort := .Values.ingress.servicePort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -41,18 +43,42 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
+          {{- range $additionalPathsHigherPriority }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+          {{- end }}
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
+          {{- range $additionalPaths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+          {{- end }}
     {{- end }}
     {{- else }}
     - http:
         paths:
+          {{- range $additionalPathsHigherPriority }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+          {{- end }}
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
+          {{- range $additionalPaths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+          {{- end }}
 
     {{- end }}
 {{- end }}

--- a/charts/k8s-service/templates/ingress.yaml
+++ b/charts/k8s-service/templates/ingress.yaml
@@ -66,7 +66,7 @@ spec:
           {{- range $additionalPathsHigherPriority }}
           - path: {{ .path }}
             backend:
-              serviceName: {{ .serviceName }}
+              serviceName: {{ if .serviceName }}{{ .serviceName }}{{ else }}{{ $fullName }}{{ end }}
               servicePort: {{ .servicePort }}
           {{- end }}
           - path: {{ $ingressPath }}
@@ -76,7 +76,7 @@ spec:
           {{- range $additionalPaths }}
           - path: {{ .path }}
             backend:
-              serviceName: {{ .serviceName }}
+              serviceName: {{ if .serviceName }}{{ .serviceName }}{{ else }}{{ $fullName }}{{ end }}
               servicePort: {{ .servicePort }}
           {{- end }}
 

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -176,6 +176,13 @@ service:
 #                                             rule for each host defined in this list. If empty, will match all hosts.
 #   - path        (string)       (required) : The url path to match to route to the Service.
 #   - servicePort (int|string)   (required) : The port (as a number) or the name of the port on the Service to route to.
+#   - additionalPaths (list[map])           : Additional paths that should be added to the ingress which will be lower
+#                                             priority than the application service path. Each item corresponds to
+#                                             another path, and should define `path`, `serviceName`, and `servicePort`.
+#   - additionalPathsHigherPriority (list[map])
+#                                           : Additional paths that should be added to the ingress which will be higher
+#                                             priority than the application service path. Each item corresponds to
+#                                             another path, and should define `path`, `serviceName`, and `servicePort`.
 #
 # The following example specifies an Ingress rule that routes chart-example.local/app to the Service port `app` with
 # TLS configured using the certificate key pair in the Secret `chart-example-tls`:

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -10,7 +10,7 @@
   version = "v0.36.0"
 
 [[projects]]
-  digest = "1:2d440c27c25ac4569edb21b27d5cfcbeb383382d3384d7691347377fbfa1f9f6"
+  digest = "1:5b3a4b76365fb5e04121ae71ae662c44b64fbec5cbccefaf5c997c6b7ebba6b2"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -24,6 +24,7 @@
     "aws/credentials/endpointcreds",
     "aws/credentials/processcreds",
     "aws/credentials/stscreds",
+    "aws/crr",
     "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
@@ -51,6 +52,7 @@
     "service/acm",
     "service/autoscaling",
     "service/cloudwatchlogs",
+    "service/dynamodb",
     "service/ec2",
     "service/ecs",
     "service/iam",
@@ -61,6 +63,7 @@
     "service/s3/s3manager",
     "service/sns",
     "service/sqs",
+    "service/ssm",
     "service/sts",
   ]
   pruneopts = "UT"
@@ -214,7 +217,7 @@
   version = "v0.4.2"
 
 [[projects]]
-  digest = "1:a10f2c49a4cdae2bfa8baff73872d3ac8163749a627d06746f9f373a0d7f4ad5"
+  digest = "1:de159f0ff408bb1d832f5da4b59e4cd3872d7b3b838761bba6ca29cebf11fe1d"
   name = "github.com/gruntwork-io/terratest"
   packages = [
     "modules/aws",
@@ -232,8 +235,8 @@
     "modules/ssh",
   ]
   pruneopts = "UT"
-  revision = "c3e1e0ab1e41a00e6c27d56216435f4b4c7311a3"
-  version = "v0.14.5"
+  revision = "367843c5fa8429d84d2e9b78402546316b54ee91"
+  version = "v0.17.6"
 
 [[projects]]
   digest = "1:a0cefd27d12712af4b5018dc7046f245e1e3b5760e2e848c30b171b570708f9b"
@@ -663,6 +666,7 @@
     "github.com/stretchr/testify/require",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
+    "k8s.io/api/extensions/v1beta1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
   ]
   solver-name = "gps-cdcl"

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"
-  version = "0.14.5"
+  version = "0.17.6"
 
 [prune]
   go-tests = true

--- a/test/k8s_service_example_test_helpers.go
+++ b/test/k8s_service_example_test_helpers.go
@@ -20,7 +20,11 @@ import (
 const (
 	WaitTimerRetries = 60
 	WaitTimerSleep   = 5 * time.Second
-	NumPodsExpected  = 3
+
+	// When expecting a timeout, do less tries to make tests go faster
+	ExpectTimeoutWaitTimerRetries = 20
+
+	NumPodsExpected = 3
 )
 
 // verifyPodsCreatedSuccessfully waits until the pods for the given helm release are created.

--- a/test/k8s_service_example_test_helpers.go
+++ b/test/k8s_service_example_test_helpers.go
@@ -20,11 +20,7 @@ import (
 const (
 	WaitTimerRetries = 60
 	WaitTimerSleep   = 5 * time.Second
-
-	// When expecting a timeout, do less tries to make tests go faster
-	ExpectTimeoutWaitTimerRetries = 20
-
-	NumPodsExpected = 3
+	NumPodsExpected  = 3
 )
 
 // verifyPodsCreatedSuccessfully waits until the pods for the given helm release are created.

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -137,5 +136,4 @@ func verifyIngressAvailable(
 		WaitTimerSleep,
 		validationFunction,
 	)
-	assert.NoError(t, err)
 }

--- a/test/k8s_service_template_render_helpers_for_test.go
+++ b/test/k8s_service_template_render_helpers_for_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	extv1beta1 "k8s.io/api/extensions/v1beta1"
 )
 
 func renderK8SServiceDeploymentWithSetValues(t *testing.T, setValues map[string]string) appsv1.Deployment {
@@ -30,4 +31,22 @@ func renderK8SServiceDeploymentWithSetValues(t *testing.T, setValues map[string]
 	var deployment appsv1.Deployment
 	helm.UnmarshalK8SYaml(t, out, &deployment)
 	return deployment
+}
+
+func renderK8SServiceIngressWithSetValues(t *testing.T, setValues map[string]string) extv1beta1.Ingress {
+	helmChartPath, err := filepath.Abs(filepath.Join("..", "charts", "k8s-service"))
+	require.NoError(t, err)
+
+	// We make sure to pass in the linter_values.yaml values file, which we assume has all the required values defined.
+	options := &helm.Options{
+		ValuesFiles: []string{filepath.Join("..", "charts", "k8s-service", "linter_values.yaml")},
+		SetValues:   setValues,
+	}
+	// Render just the deployment resource
+	out := helm.RenderTemplate(t, options, helmChartPath, []string{"templates/ingress.yaml"})
+
+	// Parse the deployment and verify the preStop hook is set
+	var ingress extv1beta1.Ingress
+	helm.UnmarshalK8SYaml(t, out, &ingress)
+	return ingress
 }

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -7,6 +7,7 @@ package test
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -223,7 +224,7 @@ func TestK8SServiceIngressAdditionalPathsAfterMainServicePath(t *testing.T) {
 	// The first path should be the main service path
 	firstPath := pathRules[0]
 	assert.Equal(t, firstPath.Path, "/app")
-	assert.Equal(t, firstPath.Backend.ServiceName, "RELEASE-NAME-linter")
+	assert.Equal(t, strings.ToLower(firstPath.Backend.ServiceName), "release-name-linter")
 	assert.Equal(t, firstPath.Backend.ServicePort.StrVal, "app")
 
 	// The second path should be the black hole
@@ -257,7 +258,7 @@ func TestK8SServiceIngressAdditionalPathsMultipleAfterMainServicePath(t *testing
 	// The first path should be the main service path
 	firstPath := pathRules[0]
 	assert.Equal(t, firstPath.Path, "/app")
-	assert.Equal(t, firstPath.Backend.ServiceName, "RELEASE-NAME-linter")
+	assert.Equal(t, strings.ToLower(firstPath.Backend.ServiceName), "release-name-linter")
 	assert.Equal(t, firstPath.Backend.ServicePort.StrVal, "app")
 
 	// The second path should be the sun
@@ -300,7 +301,7 @@ func TestK8SServiceIngressAdditionalPathsHigherPriorityBeforeMainServicePath(t *
 	// The second path should be the main service path
 	secondPath := pathRules[1]
 	assert.Equal(t, secondPath.Path, "/app")
-	assert.Equal(t, secondPath.Backend.ServiceName, "RELEASE-NAME-linter")
+	assert.Equal(t, strings.ToLower(secondPath.Backend.ServiceName), "release-name-linter")
 	assert.Equal(t, secondPath.Backend.ServicePort.StrVal, "app")
 }
 
@@ -341,6 +342,6 @@ func TestK8SServiceIngressAdditionalPathsHigherPriorityMultipleBeforeMainService
 	// The last path should be the main service path
 	thirdPath := pathRules[2]
 	assert.Equal(t, thirdPath.Path, "/app")
-	assert.Equal(t, thirdPath.Backend.ServiceName, "RELEASE-NAME-linter")
+	assert.Equal(t, strings.ToLower(thirdPath.Backend.ServiceName), "release-name-linter")
 	assert.Equal(t, thirdPath.Backend.ServicePort.StrVal, "app")
 }

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -274,6 +274,36 @@ func TestK8SServiceIngressAdditionalPathsMultipleAfterMainServicePath(t *testing
 	assert.Equal(t, thirdPath.Backend.ServicePort.IntVal, int32(80))
 }
 
+// Test that omitting a serviceName on additionalPaths reuses the application service name
+func TestK8SServiceIngressAdditionalPathsNoServiceName(t *testing.T) {
+	t.Parallel()
+
+	ingress := renderK8SServiceIngressWithSetValues(
+		t,
+		map[string]string{
+			"ingress.enabled":                        "true",
+			"ingress.path":                           "/app",
+			"ingress.servicePort":                    "app",
+			"ingress.additionalPaths[0].path":        "/black-hole",
+			"ingress.additionalPaths[0].servicePort": "3000",
+		},
+	)
+	pathRules := ingress.Spec.Rules[0].HTTP.Paths
+	assert.Equal(t, len(pathRules), 2)
+
+	// The first path should be the main service path
+	firstPath := pathRules[0]
+	assert.Equal(t, firstPath.Path, "/app")
+	assert.Equal(t, strings.ToLower(firstPath.Backend.ServiceName), "release-name-linter")
+	assert.Equal(t, firstPath.Backend.ServicePort.StrVal, "app")
+
+	// The second path should be the black hole
+	secondPath := pathRules[1]
+	assert.Equal(t, secondPath.Path, "/black-hole")
+	assert.Equal(t, strings.ToLower(secondPath.Backend.ServiceName), "release-name-linter")
+	assert.Equal(t, secondPath.Backend.ServicePort.IntVal, int32(3000))
+}
+
 // Test that setting additionalPathsHigherPriority on ingress add paths before service path
 func TestK8SServiceIngressAdditionalPathsHigherPriorityBeforeMainServicePath(t *testing.T) {
 	t.Parallel()
@@ -344,4 +374,34 @@ func TestK8SServiceIngressAdditionalPathsHigherPriorityMultipleBeforeMainService
 	assert.Equal(t, thirdPath.Path, "/app")
 	assert.Equal(t, strings.ToLower(thirdPath.Backend.ServiceName), "release-name-linter")
 	assert.Equal(t, thirdPath.Backend.ServicePort.StrVal, "app")
+}
+
+// Test that omitting a serviceName on additionalPathsHigherPriority reuses the application service name
+func TestK8SServiceIngressAdditionalPathsHigherPriorityNoServiceName(t *testing.T) {
+	t.Parallel()
+
+	ingress := renderK8SServiceIngressWithSetValues(
+		t,
+		map[string]string{
+			"ingress.enabled":     "true",
+			"ingress.path":        "/app",
+			"ingress.servicePort": "app",
+			"ingress.additionalPathsHigherPriority[0].path":        "/black-hole",
+			"ingress.additionalPathsHigherPriority[0].servicePort": "3000",
+		},
+	)
+	pathRules := ingress.Spec.Rules[0].HTTP.Paths
+	assert.Equal(t, len(pathRules), 2)
+
+	// The first path should be the black hole
+	firstPath := pathRules[0]
+	assert.Equal(t, firstPath.Path, "/black-hole")
+	assert.Equal(t, strings.ToLower(firstPath.Backend.ServiceName), "release-name-linter")
+	assert.Equal(t, firstPath.Backend.ServicePort.IntVal, int32(3000))
+
+	// The second path should be the main service path
+	secondPath := pathRules[1]
+	assert.Equal(t, secondPath.Path, "/app")
+	assert.Equal(t, strings.ToLower(secondPath.Backend.ServiceName), "release-name-linter")
+	assert.Equal(t, secondPath.Backend.ServicePort.StrVal, "app")
 }


### PR DESCRIPTION
Sometimes it is desirable to add additional path rules to the ingress resource. For example, if you wanted a HTTP => HTTPS redirect rule with the ALB ingress controller, you need to create a special catch all path that does the redirect (see https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/). This path needs to be injected before the application service path. Or you might want to create a route for a side car container that is deployed in the service.

To support these use cases, this PR introduces two new input values `additionalPaths` and `additionalPathsHigherPriority` that can be used to inject additional path rules to the ingress resource.