### PR TITLE
Add ability to set container command

### DIFF
--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -79,6 +79,10 @@ spec:
           {{- $tag := required "containerImage.tag is required" .Values.containerImage.tag }}
           image: "{{ $repo }}:{{ $tag }}"
           imagePullPolicy: {{ .Values.containerImage.pullPolicy | default "IfNotPresent" }}
+          {{- if .Values.containerCommand }}
+          command:
+{{ toYaml .Values.containerCommand | indent 12 }}
+          {{- end }}
 
           {{- if .Values.containerPorts }}
           ports:

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -40,6 +40,16 @@
 # These values have defaults, but may be overridden by the operator
 #----------------------------------------------------------------------------------------------------------------------
 
+# containerCommand is a list of strings that indicate a custom command to run for the container in place of the default
+# configured on the image. Omit to run the default command configured on the image.
+#
+# Example (run echo "Hello World"):
+#
+# containerCommand:
+#   - "echo"
+#   - "Hello World"
+containerCommand: null
+
 # containerPorts is a map that specifies the ports to open on the container. This is a nested map: the first map lists
 # the named ports, while the second layer lists the port spec. The named references can be used to refer to the specific
 # port of the container in other resources, like Service.

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -475,3 +475,31 @@ func TestK8SServiceManagedCertificateDefaultsDoesNotCreateManagedCertificate(t *
 	assert.NoError(t, err)
 	assert.Equal(t, len(rendered), 0)
 }
+
+// Test that omitting containerCommand does not set command attribute on the Deployment container spec.
+func TestK8SServiceDefaultHasNullCommandSpec(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(t, map[string]string{})
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	assert.Nil(t, appContainer.Command)
+}
+
+// Test that setting containerCommand sets the command attribute on the Deployment container spec.
+func TestK8SServiceWithContainerCommandHasCommandSpec(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"containerCommand[0]": "echo",
+			"containerCommand[1]": "Hello world",
+		},
+	)
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	assert.Equal(t, appContainer.Command, []string{"echo", "Hello world"})
+}


### PR DESCRIPTION
This adds the ability to set a custom command on the container in the Deployment. This is useful if you are trying to deploy a simple service, like a port forwarder using `nc`.