### PR TITLE
Make cert name configurable

### DIFF
--- a/charts/k8s-service/templates/gmc.yaml
+++ b/charts/k8s-service/templates/gmc.yaml
@@ -7,12 +7,12 @@ that will provision a Google managed SSL certificate.
 We declare some variables defined on the Values. These are reused in `with` and `range` blocks where the scoped variable
 (`.`) is rebound within the block.
 */ -}}
-{{- $fullName := include "k8s-service.fullname" . -}}
 {{- $domainName := .Values.google.managedCertificate.domainName -}}
+{{- $certificateName := .Values.google.managedCertificate.name -}}
 apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
-  name: {{ $fullName }}
+  name: {{ $certificateName }}
   labels:
     gruntwork.io/app-name: {{ .Values.applicationName }}
     # These labels are required by helm. You can read more about required labels in the chart best practices guide:

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -345,14 +345,17 @@ google:
   # The expected keys are:
   #   - enabled      (bool)   (required) : Whether or not the ManagedCertificate resource should be created.
   #   - domainName   (string)            : Specifies the domain that the SSL certificate will be created for
+  #   - name         (string)            : Specifies the name of the SSL certificate that you reference in Ingress with
+  #                                        networking.gke.io/managed-certificates: name
   #
-  # The following example specifies a ManagedCertificate with a domain name 'api.acme.com':
+  # The following example specifies a ManagedCertificate with a domain name 'api.acme.com' and name 'acme-cert':
   #
   # EXAMPLE:
   #
   # google:
   #   managedCertificate:
   #     enabled: true
+  #     name: acme-cert
   #     domainName: api.acme.com
   #
   # NOTE: if you enable managedCertificate, then Ingress must also be enabled.

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -438,7 +438,7 @@ func TestK8SServiceIngressAdditionalPathsHigherPriorityNoServiceName(t *testing.
 }
 
 // Test rendering Managed Certificate
-func TestK8SServiceManagedCertDomainName(t *testing.T) {
+func TestK8SServiceManagedCertDomainNameAndName(t *testing.T) {
 	t.Parallel()
 
 	cert := renderK8SServiceManagedCertificateWithSetValues(
@@ -446,12 +446,15 @@ func TestK8SServiceManagedCertDomainName(t *testing.T) {
 		map[string]string{
 			"google.managedCertificate.enabled":    "true",
 			"google.managedCertificate.domainName": "api.acme.io",
+			"google.managedCertificate.name":       "acme-cert",
 		},
 	)
 
 	domains := cert.Spec.Domains
+	certName := cert.ObjectMeta.Name
 	assert.Equal(t, len(domains), 1)
 	assert.Equal(t, domains[0], "api.acme.io")
+	assert.Equal(t, certName, "acme-cert")
 }
 
 // Test that setting ingress.enabled = false will cause the helm template to not render the ManagedCertificate resource


### PR DESCRIPTION
This PR makes the certificate name configurable. As the certificate name needs to be referenced in the ingress, users of the chart need full control over the name of the certificate. Now the name was the `fullName`, which meant that the chart user wouldn't know the name without reading the chart source code.