### PR TITLE
Fixed Ingress TLS template issue

### DIFF
--- a/charts/k8s-service/templates/ingress.yaml
+++ b/charts/k8s-service/templates/ingress.yaml
@@ -31,12 +31,12 @@ metadata:
 {{- end }}
 {{- end }}
 spec:
-  {{- if .Values.ingress.tls }}
+{{- if .Values.ingress.tls }}
+{{- with .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
-{{ toYaml . | indent 4 }}
-    {{- end }}
-  {{- end }}
+{{ toYaml . | indent 4}}
+{{- end }}
+{{- end }}
   rules:
     {{- if .Values.ingress.hosts }}
     {{- range .Values.ingress.hosts }}


### PR DESCRIPTION
This PR fixes issue https://github.com/gruntwork-io/helm-kubernetes-services/issues/34
Rendered template after fix
```yaml
# Source: k8s-service/templates/ingress.yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: release-name-test-app
  labels:
    gruntwork.io/app-name: test-app
    # These labels are required by helm. You can read more about required labels in the chart best practices guide:
    # https://docs.helm.sh/chart_best_practices/#standard-labels
    app.kubernetes.io/name: test-app
    helm.sh/chart: k8s-service-0.0.1-replace
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Tiller
spec:
  tls:
    - hosts:
      - test-app.com
      secretName: test-app-tls

  rules:
    - host: "test-app.com"
      http:
        paths:
          - path: /
            backend:
              serviceName: release-name-test-app
              servicePort: 80
```

