### PR TITLE
Added support for Security Context

### DIFF
--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -141,6 +141,10 @@ spec:
           readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 12 }}
           {{- end }}
+          {{- if .Values.securityContext }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}            
+          {{- end}}
           resources:
 {{ toYaml .Values.containerResources | indent 12 }}
 

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -100,6 +100,21 @@ livenessProbe: {}
 #     port: http
 readinessProbe: {}
 
+# securityContext is a map that specified the privillege and access control settings for a Pod of Container. Security Context
+# can be specified when the application requires additional access control permissions. More details on securityContext and supported
+# settings can be found at https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+# 
+# EXAMPLE:
+# 1) To run a container in privilleged mode
+# securityContext:
+#   privilleged: true
+# 
+# 2) To run a container as a specific user
+# securityContext:
+#   runAsUser: 2000
+securityContext: {}
+
+
 # shutdownDelay is the number of seconds to delay the shutdown sequence of the Pod by. This is implemented as a sleep
 # call in the preStop hook. By default, this chart includes a preStop hook with a shutdown delay for eventual
 # consistency reasons. You can read more about why you might want to do this in

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -136,6 +136,23 @@ func TestK8SServiceDeploymentAnnotationsRenderCorrectly(t *testing.T) {
 	assert.Equal(t, deployment.Annotations["unique-id"], uniqueID)
 }
 
+func TestK8SServiceSecurityContextAnnotationRenderCorrectly(t *testing.T) {
+	t.Parallel()
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"securityContext.privileged": "true",
+			"securityContext.runAsUser": "1000",
+		},
+	)
+	renderedContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedContainers), 1)
+	testContainer := renderedContainers[0]
+	assert.NotNil(t, testContainer.SecurityContext)
+	assert.True(t, *testContainer.SecurityContext.Privileged)
+	assert.Equal(t, *testContainer.SecurityContext.RunAsUser, int64(1000))
+}
+
 // Test that podAnnotations render correctly to annotate the Pod Template Spec on the Deployment resource
 func TestK8SServicePodAnnotationsRenderCorrectly(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Support for securityContext per the request [Issue #26 ](https://github.com/gruntwork-io/helm-kubernetes-services/issues/26)

Test cases added and passing;
```
=== RUN   TestK8SServiceSecurityContextAnnotationRenderCorrectly
=== PAUSE TestK8SServiceSecurityContextAnnotationRenderCorrectly
=== CONT  TestK8SServiceSecurityContextAnnotationRenderCorrectly
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:87: Running command helm with args [template --set securityContext.privileged=true --set securityContext.runAsUser=1000 -f /home/shenal/go/src/helm-kubernetes-services/charts/k8s-service/linter_values.yaml -x templates/deployment.yaml /home/shenal/go/src/helm-kubernetes-services/charts/k8s-service]
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158: ---
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158: # Source: k8s-service/templates/deployment.yaml
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158: apiVersion: apps/v1
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158: kind: Deployment
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158: metadata:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:   name: release-name-linter
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:   labels:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:     # These labels are required by helm. You can read more about required labels in the chart best practices guide:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:     # https://docs.helm.sh/chart_best_practices/#standard-labels
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:     helm.sh/chart: k8s-service-0.0.1-replace
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:     app.kubernetes.io/name: linter
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:     app.kubernetes.io/instance: release-name
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:     app.kubernetes.io/managed-by: Tiller
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158: spec:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:   replicas: 1
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:   selector:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:     matchLabels:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:       app.kubernetes.io/name: linter
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:       app.kubernetes.io/instance: release-name
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:   template:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:     metadata:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:       labels:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:         app.kubernetes.io/name: linter
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:         app.kubernetes.io/instance: release-name
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:     spec:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:       containers:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:         - name: linter
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:           image: "nginx:stable"
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:           imagePullPolicy: IfNotPresent
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:           ports:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:             - name: http
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:               containerPort: 80
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:               protocol: TCP
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:           securityContext:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:             privileged: true
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:             runAsUser: 1000
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:             
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:           resources:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:             {}
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:             
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:           # Include a preStop hook with a shutdown delay for eventual consistency reasons.
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:           # See https://blog.gruntwork.io/delaying-shutdown-to-wait-for-pod-deletion-propagation-445f779a8304
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:           lifecycle:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:             preStop:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:               exec:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:                 command:
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:                   - sleep
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158:                   - "5"
TestK8SServiceSecurityContextAnnotationRenderCorrectly 2019-08-28T09:06:54+05:30 command.go:158: 
--- PASS: TestK8SServiceSecurityContextAnnotationRenderCorrectly (0.05s)
PASS
ok  	helm-kubernetes-services/test	0.062s

```