### PR TITLE
Add IRSA injection

### DIFF
--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -13,9 +13,14 @@ Similarly, we need to decide whether or not there are environment variables to a
 We need this because certain sections are omitted if there are no volumes or environment variables to add.
 */ -}}
 {{/* Go Templates do not support variable updating, so we simulate it using dictionaries */}}
-{{- $hasInjectionTypes := dict "hasVolume" false "hasEnvVars" false -}}
+{{- $hasInjectionTypes := dict "hasVolume" false "hasEnvVars" false "hasIRSA" false -}}
 {{- if .Values.envVars -}}
   {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
+{{- end -}}
+{{- if gt (len .Values.aws.irsa.role_arn) 0 -}}
+  {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
+  {{- $_ := set $hasInjectionTypes "hasVolume" true -}}
+  {{- $_ := set $hasInjectionTypes "hasIRSA" true -}}
 {{- end -}}
 {{- $allSecrets := values .Values.secrets -}}
 {{- range $allSecrets -}}
@@ -163,6 +168,12 @@ spec:
           {{- if index $hasInjectionTypes "hasEnvVars" }}
           env:
           {{- end }}
+          {{- if index $hasInjectionTypes "hasIRSA" }}
+            - name: AWS_ROLE_ARN
+              value: "{{ .Values.aws.irsa.role_arn }}"
+            - name: AWS_WEB_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+          {{- end }}
           {{- range $key, $value := .Values.envVars }}
             - name: {{ $key }}
               value: {{ quote $value }}
@@ -195,6 +206,11 @@ spec:
           {{- if index $hasInjectionTypes "hasVolume" }}
           volumeMounts:
           {{- end }}
+          {{- if index $hasInjectionTypes "hasIRSA" }}
+            - name: aws-iam-token
+              mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+              readOnly: true
+          {{- end }}
           {{- range $name, $value := .Values.configMaps }}
             {{- if eq $value.as "volume" }}
             - name: {{ $name }}-volume
@@ -226,6 +242,16 @@ spec:
     {{- /* START VOLUME LOGIC */ -}}
     {{- if index $hasInjectionTypes "hasVolume" }}
       volumes:
+    {{- end }}
+    {{- if index $hasInjectionTypes "hasIRSA" }}
+        - name: aws-iam-token
+          projected:
+            defaultMode: 420
+            sources:
+              - serviceAccountToken:
+                  audience: sts.amazonaws.com
+                  expirationSeconds: 86400
+                  path: token
     {{- end }}
     {{- range $name, $value := .Values.configMaps }}
       {{- if eq $value.as "volume" }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -360,6 +360,35 @@ tolerations: []
 imagePullSecrets: []
 
 #----------------------------------------------------------------------------------------------------------------------
+# AWS SPECIFIC VALUES
+# These input values relate to AWS specific features, such as those relating to EKS and the AWS ALB Ingress Controller.
+#----------------------------------------------------------------------------------------------------------------------
+aws:
+  # irsa can be used to configure the projected tokens used in the IAM Roles for Service Accounts feature. This is
+  # useful if you are manually annotating the projected tokens into your Pods, instead of relying on the mutating
+  # admission hook.
+  #
+  # irsa is a map and expects the following keys:
+  #   - role_arn     (string) (required) : The AWS ARN that the Service Account associated with the Pod should assume.
+  #                                        Note that the projected token will not be mounted and the environment
+  #                                        variables will not be set if this is an empty string (the default).
+  #
+  # Note that you can not use any role with the IRSA feature. It must have the proper assume role IAM policy to allow
+  # the Service Account of the Pod to assume that role. See
+  # https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html for more
+  # information.
+  #
+  # EXAMPLE:
+  #
+  # aws:
+  #   irsa:
+  #     role_arn: "arn:aws:iam::123456789012:role/role-for-pod"
+  #
+  irsa:
+    role_arn: ""
+
+
+#----------------------------------------------------------------------------------------------------------------------
 # GOOGLE SPECIFIC VALUES
 # google specifies Google (GKE) specific configuration to be set via arguments/env. variables
 #----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This adds support for injecting the required annotations to the pod spec for the deployment to project the Service Account token into IAM credentials using IRSA. You can read more about the spec in the blog post for [IAM Roles for Service Accounts](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/).