### PR TITLE
Fix sidecar and additionalpaths rendering

### DIFF
--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -148,7 +148,7 @@ spec:
           {{- end }}
           {{- if .Values.securityContext }}
           securityContext:
-{{ toYaml .Values.securityContext | indent 12 }}            
+{{ toYaml .Values.securityContext | indent 12 }}
           {{- end}}
           resources:
 {{ toYaml .Values.containerResources | indent 12 }}
@@ -227,7 +227,7 @@ spec:
 
         {{- range $key, $value := .Values.sideCarContainers }}
         - name: {{ $key }}
-{{ toYaml $value | indent 12 }}
+{{ toYaml $value | indent 10 }}
         {{- end }}
 
     {{- /* START IMAGE PULL SECRETS LOGIC */ -}}

--- a/charts/k8s-service/templates/ingress.yaml
+++ b/charts/k8s-service/templates/ingress.yaml
@@ -46,7 +46,7 @@ spec:
           {{- range $additionalPathsHigherPriority }}
           - path: {{ .path }}
             backend:
-              serviceName: {{ .serviceName }}
+              serviceName: {{ if .serviceName }}{{ .serviceName }}{{ else }}{{ $fullName }}{{ end }}
               servicePort: {{ .servicePort }}
           {{- end }}
           - path: {{ $ingressPath }}
@@ -56,7 +56,7 @@ spec:
           {{- range $additionalPaths }}
           - path: {{ .path }}
             backend:
-              serviceName: {{ .serviceName }}
+              serviceName: {{ if .serviceName }}{{ .serviceName }}{{ else }}{{ $fullName }}{{ end }}
               servicePort: {{ .servicePort }}
           {{- end }}
     {{- end }}

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -612,3 +612,17 @@ func TestK8SServiceIngressMultiCert(t *testing.T) {
 	assert.Equal(t, secondTlsHosts[0], "chart1-example-tls-host")
 	assert.Equal(t, secondTlsHosts[1], "chart1-example-tls-host2")
 }
+
+func TestK8SServiceSideCarContainersRendersCorrectly(t *testing.T) {
+	t.Parallel()
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"sideCarContainers.datadog.image": "datadog/agent:latest",
+		},
+	)
+	renderedContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedContainers), 2)
+	sideCarContainer := renderedContainers[1]
+	assert.Equal(t, sideCarContainer.Image, "datadog/agent:latest")
+}


### PR DESCRIPTION
This PR fixes:

- https://github.com/gruntwork-io/helm-kubernetes-services/issues/40: `sideCarContainers` did not render correctly in the deployment
- https://github.com/gruntwork-io/helm-kubernetes-services/issues/37: `additionalPaths` and `additionalPathsHigherPriority` required a `serviceName` when using with `hosts`.

Added regression tests for each case to ensure the issue is actually fixed.