### PR TITLE
Improvements to k8s-service

### DIFF
--- a/charts/k8s-service/README.md
+++ b/charts/k8s-service/README.md
@@ -486,6 +486,27 @@ The `/*` rule which routes to port 3000 will always be used even when accessing 
 evaluated first when routing requests.
 
 
+## How do I deploy a worker service?
+
+Worker services typically do not have a RPC or web server interface to access it. Instead, worker services act on their
+own and typically reach out to get the data they need. These services should be deployed without any ports exposed.
+However, by default `k8s-service` will deploy an internally exposed service with port 80 open.
+
+To disable the default port, you can use the following `values.yaml` inputs:
+
+```
+containerPorts:
+  http:
+    disabled: true
+
+service:
+  enabled: false
+```
+
+This will override the default settings such that only the `Deployment` resource is created, with no ports exposed on
+the container.
+
+
 ## How do I check the status of the rollout?
 
 This Helm Chart packages your application into a `Deployment` controller. The `Deployment` controller will be
@@ -1013,7 +1034,7 @@ spec:
     spec:
       containers:
         ... The first entry relates to the application ...
-        - name: datadog 
+        - name: datadog
           image: datadog/agent:latest
           env:
             - name: DD_API_KEY

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -13,9 +13,18 @@ Similarly, we need to decide whether or not there are environment variables to a
 We need this because certain sections are omitted if there are no volumes or environment variables to add.
 */ -}}
 {{/* Go Templates do not support variable updating, so we simulate it using dictionaries */}}
-{{- $hasInjectionTypes := dict "hasVolume" false "hasEnvVars" false "hasIRSA" false -}}
+{{- $hasInjectionTypes := dict "hasVolume" false "hasEnvVars" false "hasIRSA" false "exposePorts" false -}}
 {{- if .Values.envVars -}}
   {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
+{{- end -}}
+{{- $allContainerPorts := values .Values.containerPorts -}}
+{{- range $allContainerPorts -}}
+  {{/* We are exposing ports if there is at least one key in containerPorts that is not disabled (disabled = false or
+       omitted)
+  */}}
+  {{- if or (not (hasKey . "disabled")) (not .disabled) -}}
+    {{- $_ := set $hasInjectionTypes "exposePorts" true -}}
+  {{- end -}}
 {{- end -}}
 {{- if gt (len .Values.aws.irsa.role_arn) 0 -}}
   {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
@@ -96,7 +105,7 @@ spec:
 {{ toYaml .Values.containerCommand | indent 12 }}
           {{- end }}
 
-          {{- if .Values.containerPorts }}
+          {{- if index $hasInjectionTypes "exposePorts" }}
           ports:
             {{- /*
               NOTE: we check for a disabled flag here so that users of the helm

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -78,6 +78,13 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
     spec:
+      {{- if gt (len .Values.serviceAccount.name) 0 }}
+      serviceAccountName: "{{ .Values.serviceAccount.name }}"
+      {{- end }}
+      {{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
+      automountServiceAccountToken : {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
+
       containers:
         - name: {{ .Values.applicationName }}
           {{- $repo := required "containerImage.repository is required" .Values.containerImage.repository }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -234,6 +234,8 @@ ingress:
 # application container. The keys will be mapped to environment variable keys, with the values mapping to the
 # environment variable values.
 #
+# NOTE: If you wish to set environment variables using Secrets, see the `secrets` setting in this file.
+#
 # The following example configures two environment variables, DB_HOST and DB_PORT:
 #
 # EXAMPLE:

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -103,12 +103,12 @@ readinessProbe: {}
 # securityContext is a map that specified the privillege and access control settings for a Pod of Container. Security Context
 # can be specified when the application requires additional access control permissions. More details on securityContext and supported
 # settings can be found at https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-# 
+#
 # EXAMPLE:
 # 1) To run a container in privilleged mode
 # securityContext:
 #   privilleged: true
-# 
+#
 # 2) To run a container as a specific user
 # securityContext:
 #   runAsUser: 2000
@@ -358,6 +358,19 @@ tolerations: []
 # imagePullSecrets lists the Secret resources that should be used for accessing private registries. Each item in the
 # list is a string that corresponds to the Secret name.
 imagePullSecrets: []
+
+# serviceAccount is a map that configures the ServiceAccount information for the Pod.
+# The expected keys of serviceAccount are:
+#   - name                         (string) : The name of the ServiceAccount in the Namespace where the Pod is deployed
+#                                             that should be used. By default this is the default ServiceAccount of the
+#                                             Namespace.
+#   - automountServiceAccountToken (bool)   : Whether or not to automatically mount the ServiceAccount token as a volume
+#                                             into the Pod. Note that this can be used to override the equivalent config
+#                                             on the SerrviceAccount.
+#
+# The default config uses empty string to indicate that the default service account should be used.
+serviceAccount:
+  name: ""
 
 #----------------------------------------------------------------------------------------------------------------------
 # AWS SPECIFIC VALUES

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -58,7 +58,7 @@ containerCommand: null
 #   - protocol (string) (required) : The network protocol (e.g TCP or UDP) that is exposed.
 #   - disabled (bool)              : Whether or not this port is disabled. This defaults to false if unset. Provided as a
 #                                    convenience to override the default ports on the commandline. For example, to
-#                                    disable the default port, you can pass `--set containerPorts.https.disabled=true`.
+#                                    disable the default port, you can pass `--set containerPorts.http.disabled=true`.
 #
 # The default config exposes TCP port 80 and binds the name `http` to it.
 containerPorts:

--- a/test/k8s_service_service_account_template_test.go
+++ b/test/k8s_service_service_account_template_test.go
@@ -1,0 +1,74 @@
+// +build all tpl
+
+// NOTE: We use build flags to differentiate between template tests and integration tests so that you can conveniently
+// run just the template tests. See the test README for more information.
+
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestK8SServiceServiceAccountInjection(t *testing.T) {
+	t.Parallel()
+	randomSAName := strings.ToLower(random.UniqueId())
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"serviceAccount.name": randomSAName,
+		},
+	)
+	renderedServiceAccountName := deployment.Spec.Template.Spec.ServiceAccountName
+	assert.Equal(t, renderedServiceAccountName, randomSAName)
+}
+
+func TestK8SServiceServiceAccountNoNameIsEmpty(t *testing.T) {
+	t.Parallel()
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{},
+	)
+	renderedServiceAccountName := deployment.Spec.Template.Spec.ServiceAccountName
+	assert.Equal(t, renderedServiceAccountName, "")
+}
+
+func TestK8SServiceServiceAccountAutomountTokenTrueInjection(t *testing.T) {
+	t.Parallel()
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"serviceAccount.automountServiceAccountToken": "true",
+		},
+	)
+	renderedServiceAccountTokenAutomountSetting := deployment.Spec.Template.Spec.AutomountServiceAccountToken
+	require.NotNil(t, renderedServiceAccountTokenAutomountSetting)
+	assert.True(t, *renderedServiceAccountTokenAutomountSetting)
+}
+
+func TestK8SServiceServiceAccountAutomountTokenFalseInjection(t *testing.T) {
+	t.Parallel()
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"serviceAccount.automountServiceAccountToken": "false",
+		},
+	)
+	renderedServiceAccountTokenAutomountSetting := deployment.Spec.Template.Spec.AutomountServiceAccountToken
+	require.NotNil(t, renderedServiceAccountTokenAutomountSetting)
+	assert.False(t, *renderedServiceAccountTokenAutomountSetting)
+}
+
+func TestK8SServiceServiceAccountOmitAutomountToken(t *testing.T) {
+	t.Parallel()
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{},
+	)
+	renderedServiceAccountTokenAutomountSetting := deployment.Spec.Template.Spec.AutomountServiceAccountToken
+	assert.Nil(t, renderedServiceAccountTokenAutomountSetting)
+}

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -689,3 +689,17 @@ func TestK8SServiceSideCarContainersRendersCorrectly(t *testing.T) {
 	sideCarContainer := renderedContainers[1]
 	assert.Equal(t, sideCarContainer.Image, "datadog/agent:latest")
 }
+
+func TestK8SServiceDisableDefaultPort(t *testing.T) {
+	t.Parallel()
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"containerPorts.http.disabled": "true",
+		},
+	)
+	renderedContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedContainers), 1)
+	mainContainer := renderedContainers[0]
+	assert.Equal(t, len(mainContainer.Ports), 0)
+}


### PR DESCRIPTION
- Allow setting a different service account on the Pod
- Allow disabling the default ports that are exposed
- Update README to include information on how to deploy a worker service
- Update values docs to link to `secrets` from the `envVars` settings.
