### PR TITLE
feat: issue 48 adding Horizontal Pod Autoscaler resource

### DIFF
--- a/charts/k8s-service/README.md
+++ b/charts/k8s-service/README.md
@@ -37,6 +37,9 @@ The following resources will be deployed with this Helm Chart, depending on whic
 - `Ingress`: The `Ingress` resource providing host and path routing rules to the `Service` for the deployed `Ingress`
              controller in the cluster. Created only if you configure the `ingress` input (and set
              `ingress.enabled = true`).
+- `Horizontal Pod Autoscaler`: The `Horizontal Pod Autoscaler` automatically scales the number of pods in a replication
+                                controller, deployment, replica set or stateful set based on observed CPU or memory utilization.
+                                Created only if the user sets `horizontalPodAutoscaler.enabled = true`.
 - `PodDisruptionBudget`: The `PodDisruptionBudget` resource that specifies a disruption budget for the `Pods` managed by
                          the `Deployment`. This manages how many pods can be disrupted by a voluntary disruption (e.g
                          node maintenance). Created if you specify a non-zero value for the `minPodsAvailable` input

--- a/charts/k8s-service/templates/horizontalpodautoscaler.yaml
+++ b/charts/k8s-service/templates/horizontalpodautoscaler.yaml
@@ -5,10 +5,6 @@ metadata:
   name: {{ template "k8s-service.fullname" . }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: php-apache
   minReplicas: {{ .Values.horizontalPodAutoscaler.minReplicas }}
   maxReplicas: {{ .Values.horizontalPodAutoscaler.maxReplicas }}
   metrics:
@@ -24,16 +20,4 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.horizontalPodAutoscaler.avgMemoryUtilization }}
-status:
-  observedGeneration: 1
-  lastScaleTime: <some-time>
-  currentReplicas: 1
-  desiredReplicas: 1
-  currentMetrics:
-    - type: Resource
-      resource:
-        name: cpu
-        current:
-          averageUtilization: 0
-          averageValue: 0
 {{- end }}

--- a/charts/k8s-service/templates/horizontalpodautoscaler.yaml
+++ b/charts/k8s-service/templates/horizontalpodautoscaler.yaml
@@ -18,6 +18,12 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.horizontalPodAutoscaler.avgCpuUtilization }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.horizontalPodAutoscaler.avgMemoryUtilization }}
 status:
   observedGeneration: 1
   lastScaleTime: <some-time>
@@ -30,3 +36,4 @@ status:
         current:
           averageUtilization: 0
           averageValue: 0
+{{- end }}

--- a/charts/k8s-service/templates/horizontalpodautoscaler.yaml
+++ b/charts/k8s-service/templates/horizontalpodautoscaler.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "k8s-service.fullname" . }}
   namespace: {{ $.Release.Namespace }}
 spec:
+  scaleTargetRef: {{ .Values.horizontalPodAutoscaler.scaleTargetRef }}
   minReplicas: {{ .Values.horizontalPodAutoscaler.minReplicas }}
   maxReplicas: {{ .Values.horizontalPodAutoscaler.maxReplicas }}
   metrics:

--- a/charts/k8s-service/templates/horizontalpodautoscaler.yaml
+++ b/charts/k8s-service/templates/horizontalpodautoscaler.yaml
@@ -1,23 +1,23 @@
-{{- if .Values.hpa.enabled }}
+{{- if .Values.horizontalPodAutoscaler.enabled }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "k8s-service.fullname" . }}
-  namespace: default
+  namespace: {{ $.Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: php-apache
-  minReplicas: 1
-  maxReplicas: 10
+  minReplicas: {{ .Values.horizontalPodAutoscaler.minReplicas }}
+  maxReplicas: {{ .Values.horizontalPodAutoscaler.maxReplicas }}
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 50
+          averageUtilization: {{ .Values.horizontalPodAutoscaler.avgCpuUtilization }}
 status:
   observedGeneration: 1
   lastScaleTime: <some-time>

--- a/charts/k8s-service/templates/horizontalpodautoscaler.yaml
+++ b/charts/k8s-service/templates/horizontalpodautoscaler.yaml
@@ -2,26 +2,30 @@
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "k8s-service.fullname" . }}
+  name: {{ include "k8s-service.fullname" . }}
   namespace: {{ $.Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "k8s-service.fullname" . }}
+    name: {{ include "k8s-service.fullname" . }}
   minReplicas: {{ .Values.horizontalPodAutoscaler.minReplicas }}
   maxReplicas: {{ .Values.horizontalPodAutoscaler.maxReplicas }}
   metrics:
+  {{ if .Values.horizontalPodAutoscaler.avgCpuUtilization }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
           averageUtilization: {{ .Values.horizontalPodAutoscaler.avgCpuUtilization }}
+  {{- end }}
+  {{ if .Values.horizontalPodAutoscaler.avgMemoryUtilization }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: {{ .Values.horizontalPodAutoscaler.avgMemoryUtilization }}
+  {{- end }}
 {{- end }}

--- a/charts/k8s-service/templates/horizontalpodautoscaler.yaml
+++ b/charts/k8s-service/templates/horizontalpodautoscaler.yaml
@@ -5,7 +5,10 @@ metadata:
   name: {{ template "k8s-service.fullname" . }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  scaleTargetRef: {{ .Values.horizontalPodAutoscaler.scaleTargetRef }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "k8s-service.fullname" . }}
   minReplicas: {{ .Values.horizontalPodAutoscaler.minReplicas }}
   maxReplicas: {{ .Values.horizontalPodAutoscaler.maxReplicas }}
   metrics:

--- a/charts/k8s-service/templates/horizontalpodautoscaler.yaml
+++ b/charts/k8s-service/templates/horizontalpodautoscaler.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "k8s-service.fullname" . }}
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+status:
+  observedGeneration: 1
+  lastScaleTime: <some-time>
+  currentReplicas: 1
+  desiredReplicas: 1
+  currentMetrics:
+    - type: Resource
+      resource:
+        name: cpu
+        current:
+          averageUtilization: 0
+          averageValue: 0

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -412,6 +412,7 @@ serviceAccount:
 #   - maxReplicas                  (int)    : The maximum amount of replicas allowed
 #   - avgCpuUtilization            (int)    : The target average CPU utilization to be used with the metrics
 #   - avgMemoryUtilization         (int)    : The target average Memory utilization to be used with the metrics
+#   - scaleTargetRef               (map)    : The scale target reference to know what is being scaled
 #
 # The default config will not create the Horizontal Pod Autoscaler by setting enabled = false, the default values are
 # set so if enabled is true the horizontalPodAutoscaler has valid values.
@@ -421,6 +422,7 @@ horizontalPodAutoscaler:
   maxReplicas: 10
   avgCpuUtilization: 50
   avgMemoryUtilization: 50
+  scaleTargetRef: {}
 
 
 #----------------------------------------------------------------------------------------------------------------------

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -411,6 +411,7 @@ serviceAccount:
 #   - minReplicas                  (int)    : The minimum amount of replicas allowed
 #   - maxReplicas                  (int)    : The maximum amount of replicas allowed
 #   - avgCpuUtilization            (int)    : The target average CPU utilization to be used with the metrics
+#   - avgMemoryUtilization         (int)    : The target average Memory utilization to be used with the metrics
 #
 # The default config will not create the Horizontal Pod Autoscaler by setting enabled = false, the default values are
 # set so if enabled is true the horizontalPodAutoscaler has valid values.
@@ -419,6 +420,7 @@ horizontalPodAutoscaler:
   minReplicas: 1
   maxReplicas: 10
   avgCpuUtilization: 50
+  avgMemoryUtilization: 50
 
 
 #----------------------------------------------------------------------------------------------------------------------

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -404,6 +404,23 @@ imagePullSecrets: []
 serviceAccount:
   name: ""
 
+# horizontalPodAutoscaler is a map that configures the Horizontal Pod Autoscaler information for this pod
+# The expected keys of hpa are:
+#   - enabled                      (bool)   : Whether or not Horizontal Pod Autoscaler should be created, if false the
+#                                             Horizontal Pod Autoscaler will not be created
+#   - minReplicas                  (int)    : The minimum amount of replicas allowed
+#   - maxReplicas                  (int)    : The maximum amount of replicas allowed
+#   - avgCpuUtilization            (int)    : The target average CPU utilization to be used with the metrics
+#
+# The default config will not create the Horizontal Pod Autoscaler by setting enabled = false, the default values are
+# set so if enabled is true the horizontalPodAutoscaler has valid values.
+horizontalPodAutoscaler:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  avgCpuUtilization: 50
+
+
 #----------------------------------------------------------------------------------------------------------------------
 # AWS SPECIFIC VALUES
 # These input values relate to AWS specific features, such as those relating to EKS and the AWS ALB Ingress Controller.

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -419,8 +419,6 @@ horizontalPodAutoscaler:
   enabled: false
   minReplicas: 1
   maxReplicas: 10
-  avgCpuUtilization: 50
-  avgMemoryUtilization: 50
 
 
 #----------------------------------------------------------------------------------------------------------------------

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -412,7 +412,6 @@ serviceAccount:
 #   - maxReplicas                  (int)    : The maximum amount of replicas allowed
 #   - avgCpuUtilization            (int)    : The target average CPU utilization to be used with the metrics
 #   - avgMemoryUtilization         (int)    : The target average Memory utilization to be used with the metrics
-#   - scaleTargetRef               (map)    : The scale target reference to know what is being scaled
 #
 # The default config will not create the Horizontal Pod Autoscaler by setting enabled = false, the default values are
 # set so if enabled is true the horizontalPodAutoscaler has valid values.
@@ -422,7 +421,6 @@ horizontalPodAutoscaler:
   maxReplicas: 10
   avgCpuUtilization: 50
   avgMemoryUtilization: 50
-  scaleTargetRef: {}
 
 
 #----------------------------------------------------------------------------------------------------------------------

--- a/test/k8s_service_horizontal_pod_autoscaler_template_test.go
+++ b/test/k8s_service_horizontal_pod_autoscaler_template_test.go
@@ -1,0 +1,83 @@
+// +build all tpl
+
+// NOTE: We use build flags to differentiate between template tests and integration tests so that you can conveniently
+// run just the template tests. See the test README for more information.
+
+package test
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that setting horizontalPodAutoscaler.enabled = true will cause the helm template to render the Horizontal Pod
+// Autoscaler resource
+func TestK8SServiceHorizontalPodAutoscalerCreateTrueCreatesHorizontalPodAutoscaler(t *testing.T) {
+	t.Parallel()
+	minReplicas := "20"
+	maxReplicas := "30"
+	avgCpuUtil := "55"
+	avgMemoryUtil := "65"
+
+	helmChartPath, err := filepath.Abs(filepath.Join("..", "charts", "k8s-service"))
+	require.NoError(t, err)
+
+	// We make sure to pass in the linter_values.yaml values file, which we assume has all the required values defined.
+	// We then use SetValues to override all the defaults.
+	options := &helm.Options{
+		ValuesFiles: []string{filepath.Join("..", "charts", "k8s-service", "linter_values.yaml")},
+		SetValues: map[string]string{
+			"horizontalPodAutoscaler.enabled":              "true",
+			"horizontalPodAutoscaler.minReplicas":          minReplicas,
+			"horizontalPodAutoscaler.maxReplicas":          maxReplicas,
+			"horizontalPodAutoscaler.avgCpuUtilization":    avgCpuUtil,
+			"horizontalPodAutoscaler.avgMemoryUtilization": avgMemoryUtil,
+		},
+	}
+	out := helm.RenderTemplate(t, options, helmChartPath, []string{"templates/horizontalpodautoscaler.yaml"})
+
+	// We take the output and render it to a map to validate it has created a Horizontal Pod Autoscaler output or not
+	rendered := map[string]interface{}{}
+	err = yaml.Unmarshal([]byte(out), &rendered)
+	assert.NoError(t, err)
+	assert.NotEqual(t, 0, len(rendered))
+	min, err := strconv.ParseFloat(minReplicas, 64)
+	max, err := strconv.ParseFloat(maxReplicas, 64)
+	avgCpu, err := strconv.ParseFloat(avgCpuUtil, 64)
+	avgMem, err := strconv.ParseFloat(avgMemoryUtil, 64)
+	assert.Equal(t, min, rendered["spec"].(map[string]interface{})["minReplicas"])
+	assert.Equal(t, max, rendered["spec"].(map[string]interface{})["maxReplicas"])
+	assert.Equal(t, avgCpu, rendered["spec"].(map[string]interface{})["metrics"].([]interface{})[0].(map[string]interface{})["resource"].(map[string]interface{})["target"].(map[string]interface{})["averageUtilization"])
+	assert.Equal(t, avgMem, rendered["spec"].(map[string]interface{})["metrics"].([]interface{})[1].(map[string]interface{})["resource"].(map[string]interface{})["target"].(map[string]interface{})["averageUtilization"])
+}
+
+// Test that setting horizontalPodAutoscaler.enabled = false will cause the helm template to not render the Horizontal
+// Pod Autoscaler resource
+func TestK8SServiceHorizontalPodAutoscalerCreateFalse(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs(filepath.Join("..", "charts", "k8s-service"))
+	require.NoError(t, err)
+
+	// We make sure to pass in the linter_values.yaml values file, which we assume has all the required values defined.
+	// We then use SetValues to override all the defaults.
+	options := &helm.Options{
+		ValuesFiles: []string{filepath.Join("..", "charts", "k8s-service", "linter_values.yaml")},
+		SetValues: map[string]string{
+			"horizontalPodAutoscaler.enabled": "false",
+		},
+	}
+	out := helm.RenderTemplate(t, options, helmChartPath, []string{"templates/horizontalpodautoscaler.yaml"})
+
+	// We take the output and render it to a map to validate it has created a Horizontal Pod Autoscaler output or not
+	rendered := map[string]interface{}{}
+	err = yaml.Unmarshal([]byte(out), &rendered)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(rendered))
+}

--- a/test/k8s_service_horizontal_pod_autoscaler_template_test.go
+++ b/test/k8s_service_horizontal_pod_autoscaler_template_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 // Test that setting horizontalPodAutoscaler.enabled = true will cause the helm template to render the Horizontal Pod
-// Autoscaler resource
-func TestK8SServiceHorizontalPodAutoscalerCreateTrueCreatesHorizontalPodAutoscaler(t *testing.T) {
+// Autoscaler resource with both metrics
+func TestK8SServiceHorizontalPodAutoscalerCreateTrueCreatesHorizontalPodAutoscalerWithAllMetrics(t *testing.T) {
 	t.Parallel()
 	minReplicas := "20"
 	maxReplicas := "30"
@@ -80,4 +80,111 @@ func TestK8SServiceHorizontalPodAutoscalerCreateFalse(t *testing.T) {
 	err = yaml.Unmarshal([]byte(out), &rendered)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(rendered))
+}
+
+// Test that setting horizontalPodAutoscaler.enabled = true will cause the helm template to render the Horizontal Pod
+// Autoscaler resource with the cpu metric
+func TestK8SServiceHorizontalPodAutoscalerCreateTrueCreatesHorizontalPodAutoscalerWithCpuMetric(t *testing.T) {
+	t.Parallel()
+	minReplicas := "20"
+	maxReplicas := "30"
+	avgCpuUtil := "55"
+
+	helmChartPath, err := filepath.Abs(filepath.Join("..", "charts", "k8s-service"))
+	require.NoError(t, err)
+
+	// We make sure to pass in the linter_values.yaml values file, which we assume has all the required values defined.
+	// We then use SetValues to override all the defaults.
+	options := &helm.Options{
+		ValuesFiles: []string{filepath.Join("..", "charts", "k8s-service", "linter_values.yaml")},
+		SetValues: map[string]string{
+			"horizontalPodAutoscaler.enabled":           "true",
+			"horizontalPodAutoscaler.minReplicas":       minReplicas,
+			"horizontalPodAutoscaler.maxReplicas":       maxReplicas,
+			"horizontalPodAutoscaler.avgCpuUtilization": avgCpuUtil,
+		},
+	}
+	out := helm.RenderTemplate(t, options, helmChartPath, []string{"templates/horizontalpodautoscaler.yaml"})
+
+	// We take the output and render it to a map to validate it has created a Horizontal Pod Autoscaler output or not
+	rendered := map[string]interface{}{}
+	err = yaml.Unmarshal([]byte(out), &rendered)
+	assert.NoError(t, err)
+	assert.NotEqual(t, 0, len(rendered))
+	min, err := strconv.ParseFloat(minReplicas, 64)
+	max, err := strconv.ParseFloat(maxReplicas, 64)
+	avgCpu, err := strconv.ParseFloat(avgCpuUtil, 64)
+	assert.Equal(t, min, rendered["spec"].(map[string]interface{})["minReplicas"])
+	assert.Equal(t, max, rendered["spec"].(map[string]interface{})["maxReplicas"])
+	assert.Equal(t, avgCpu, rendered["spec"].(map[string]interface{})["metrics"].([]interface{})[0].(map[string]interface{})["resource"].(map[string]interface{})["target"].(map[string]interface{})["averageUtilization"])
+}
+
+// Test that setting horizontalPodAutoscaler.enabled = true will cause the helm template to render the Horizontal Pod
+// Autoscaler resource with the memory metric
+func TestK8SServiceHorizontalPodAutoscalerCreateTrueCreatesHorizontalPodAutoscalerWithMemoryMetric(t *testing.T) {
+	t.Parallel()
+	minReplicas := "20"
+	maxReplicas := "30"
+	avgMemoryUtil := "65"
+
+	helmChartPath, err := filepath.Abs(filepath.Join("..", "charts", "k8s-service"))
+	require.NoError(t, err)
+
+	// We make sure to pass in the linter_values.yaml values file, which we assume has all the required values defined.
+	// We then use SetValues to override all the defaults.
+	options := &helm.Options{
+		ValuesFiles: []string{filepath.Join("..", "charts", "k8s-service", "linter_values.yaml")},
+		SetValues: map[string]string{
+			"horizontalPodAutoscaler.enabled":              "true",
+			"horizontalPodAutoscaler.minReplicas":          minReplicas,
+			"horizontalPodAutoscaler.maxReplicas":          maxReplicas,
+			"horizontalPodAutoscaler.avgMemoryUtilization": avgMemoryUtil,
+		},
+	}
+	out := helm.RenderTemplate(t, options, helmChartPath, []string{"templates/horizontalpodautoscaler.yaml"})
+
+	// We take the output and render it to a map to validate it has created a Horizontal Pod Autoscaler output or not
+	rendered := map[string]interface{}{}
+	err = yaml.Unmarshal([]byte(out), &rendered)
+	assert.NoError(t, err)
+	assert.NotEqual(t, 0, len(rendered))
+	min, err := strconv.ParseFloat(minReplicas, 64)
+	max, err := strconv.ParseFloat(maxReplicas, 64)
+	avgMem, err := strconv.ParseFloat(avgMemoryUtil, 64)
+	assert.Equal(t, min, rendered["spec"].(map[string]interface{})["minReplicas"])
+	assert.Equal(t, max, rendered["spec"].(map[string]interface{})["maxReplicas"])
+	assert.Equal(t, avgMem, rendered["spec"].(map[string]interface{})["metrics"].([]interface{})[0].(map[string]interface{})["resource"].(map[string]interface{})["target"].(map[string]interface{})["averageUtilization"])
+}
+
+// Test that setting horizontalPodAutoscaler.enabled = true will cause the helm template to render the Horizontal Pod
+// Autoscaler resource with the no metrics
+func TestK8SServiceHorizontalPodAutoscalerCreateTrueCreatesHorizontalPodAutoscalerWithNoMetrics(t *testing.T) {
+	t.Parallel()
+	minReplicas := "20"
+	maxReplicas := "30"
+
+	helmChartPath, err := filepath.Abs(filepath.Join("..", "charts", "k8s-service"))
+	require.NoError(t, err)
+
+	// We make sure to pass in the linter_values.yaml values file, which we assume has all the required values defined.
+	// We then use SetValues to override all the defaults.
+	options := &helm.Options{
+		ValuesFiles: []string{filepath.Join("..", "charts", "k8s-service", "linter_values.yaml")},
+		SetValues: map[string]string{
+			"horizontalPodAutoscaler.enabled":     "true",
+			"horizontalPodAutoscaler.minReplicas": minReplicas,
+			"horizontalPodAutoscaler.maxReplicas": maxReplicas,
+		},
+	}
+	out := helm.RenderTemplate(t, options, helmChartPath, []string{"templates/horizontalpodautoscaler.yaml"})
+
+	// We take the output and render it to a map to validate it has created a Horizontal Pod Autoscaler output or not
+	rendered := map[string]interface{}{}
+	err = yaml.Unmarshal([]byte(out), &rendered)
+	assert.NoError(t, err)
+	assert.NotEqual(t, 0, len(rendered))
+	min, err := strconv.ParseFloat(minReplicas, 64)
+	max, err := strconv.ParseFloat(maxReplicas, 64)
+	assert.Equal(t, min, rendered["spec"].(map[string]interface{})["minReplicas"])
+	assert.Equal(t, max, rendered["spec"].(map[string]interface{})["maxReplicas"])
 }


### PR DESCRIPTION
This PR will resolve issue #48 by adding the template for horizontal pod autoscaler with for the time being the cpu and memory resources. The other option is to allow the user to supply the whole metrics block but this is a start 