### PR TITLE
Remove link to faq

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,12 +65,6 @@ Library], a collection of reusable, battle-tested, production ready infrastructu
 * link:/examples[examples]: This folder contains working examples of how to use the submodules.
 * link:/test[test]: Automated tests for the modules and examples.
 
-=== Gruntwork analysis
-
-* link:/_docs/faq.md#why-kubernetes[Why Kubernetes]: Learn why you may want to use Kubernetes in the first place.
-
-
-
 
 == Deploy
 


### PR DESCRIPTION
This link was a 404. Removing as discussed in: https://gruntwork-io.slack.com/archives/C76UJFUEL/p1579624661058000?thread_ts=1579539740.041000&cid=C76UJFUEL