### PR TITLE
Add additional_container_env value for arbitrary environment settings

### DIFF
--- a/charts/k8s-service/templates/canarydeployment.yaml
+++ b/charts/k8s-service/templates/canarydeployment.yaml
@@ -22,6 +22,9 @@ We need this because certain sections are omitted if there are no volumes or env
 {{- if .Values.envVars -}}
   {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
 {{- end -}}
+{{- if .Values.additional_container_env -}}
+  {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
+{{- end -}}
 {{- $allContainerPorts := values .Values.containerPorts -}}
 {{- range $allContainerPorts -}}
   {{/* We are exposing ports if there is at least one key in containerPorts that is not disabled (disabled = false or
@@ -200,6 +203,9 @@ spec:
           {{- range $key, $value := .Values.envVars }}
             - name: {{ $key }}
               value: {{ quote $value }}
+          {{- end }}
+          {{- if .Values.additional_container_env }}
+{{ toYaml .Values.additional_container_env | indent 12 }}
           {{- end }}
           {{- range $name, $value := .Values.configMaps }}
             {{- if eq $value.as "environment" }}

--- a/charts/k8s-service/templates/canarydeployment.yaml
+++ b/charts/k8s-service/templates/canarydeployment.yaml
@@ -22,7 +22,7 @@ We need this because certain sections are omitted if there are no volumes or env
 {{- if .Values.envVars -}}
   {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
 {{- end -}}
-{{- if .Values.additional_container_env -}}
+{{- if .Values.additionalContainerEnv -}}
   {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
 {{- end -}}
 {{- $allContainerPorts := values .Values.containerPorts -}}
@@ -204,8 +204,8 @@ spec:
             - name: {{ $key }}
               value: {{ quote $value }}
           {{- end }}
-          {{- if .Values.additional_container_env }}
-{{ toYaml .Values.additional_container_env | indent 12 }}
+          {{- if .Values.additionalContainerEnv }}
+{{ toYaml .Values.additionalContainerEnv | indent 12 }}
           {{- end }}
           {{- range $name, $value := .Values.configMaps }}
             {{- if eq $value.as "environment" }}

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -17,6 +17,9 @@ We need this because certain sections are omitted if there are no volumes or env
 {{- if .Values.envVars -}}
   {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
 {{- end -}}
+{{- if .Values.additional_container_env -}}
+  {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
+{{- end -}}
 {{- $allContainerPorts := values .Values.containerPorts -}}
 {{- range $allContainerPorts -}}
   {{/* We are exposing ports if there is at least one key in containerPorts that is not disabled (disabled = false or
@@ -195,6 +198,9 @@ spec:
           {{- range $key, $value := .Values.envVars }}
             - name: {{ $key }}
               value: {{ quote $value }}
+          {{- end }}
+          {{- if .Values.additional_container_env }}
+{{ toYaml .Values.additional_container_env | indent 12 }}
           {{- end }}
           {{- range $name, $value := .Values.configMaps }}
             {{- if eq $value.as "environment" }}

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -17,7 +17,7 @@ We need this because certain sections are omitted if there are no volumes or env
 {{- if .Values.envVars -}}
   {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
 {{- end -}}
-{{- if .Values.additional_container_env -}}
+{{- if .Values.additionalContainerEnv -}}
   {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
 {{- end -}}
 {{- $allContainerPorts := values .Values.containerPorts -}}
@@ -199,8 +199,8 @@ spec:
             - name: {{ $key }}
               value: {{ quote $value }}
           {{- end }}
-          {{- if .Values.additional_container_env }}
-{{ toYaml .Values.additional_container_env | indent 12 }}
+          {{- if .Values.additionalContainerEnv }}
+{{ toYaml .Values.additionalContainerEnv | indent 12 }}
           {{- end }}
           {{- range $name, $value := .Values.configMaps }}
             {{- if eq $value.as "environment" }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -297,11 +297,11 @@ ingress:
 #   DB_PORT: 3306
 envVars: {}
 
-# additional_container_env is a list of additional environment variables
+# additionalContainerEnv is a list of additional environment variables
 # definitions that will be inserted into the Container's environment YAML.
 #
 # Example:
-# additional_container_env:
+# additionalContainerEnv:
 #   - name: DD_AGENT_HOST
 #     valueFrom:
 #       fieldRef:
@@ -310,7 +310,7 @@ envVars: {}
 #     valueFrom:
 #       fieldRef:
 #         fieldPath: metadata.uid
-additional_container_env: {}
+additionalContainerEnv: {}
 
 # configMaps is a map that specifies the ConfigMap resources that should be exposed to the main application container. Each
 # entry in the map represents a ConfigMap resource. The key refers to the name of the ConfigMap that should be exposed,

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -297,6 +297,21 @@ ingress:
 #   DB_PORT: 3306
 envVars: {}
 
+# additional_container_env is a list of additional environment variables
+# definitions that will be inserted into the Container's environment YAML.
+#
+# Example:
+# additional_container_env:
+#   - name: DD_AGENT_HOST
+#     valueFrom:
+#       fieldRef:
+#         fieldPath: status.hostIP
+#   - name: DD_ENTITY_ID
+#     valueFrom:
+#       fieldRef:
+#         fieldPath: metadata.uid
+additional_container_env: {}
+
 # configMaps is a map that specifies the ConfigMap resources that should be exposed to the main application container. Each
 # entry in the map represents a ConfigMap resource. The key refers to the name of the ConfigMap that should be exposed,
 # with the value specifying how to expose the ConfigMap. The value is also a map and has the following attributes:


### PR DESCRIPTION
This chart value allows one to specify arbitrary environment settings
for the main container.  This includes being able to do field references
to ingest the hostIP/podIP/etc.