### PR TITLE
[skip ci] Add mention of where to get charts at top of README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ endif::[]
 image:https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg[link="https://gruntwork.io/?ref=repo_k8s_service"]
 
 This repo contains Helm Charts for deploying your applications on Kubernetes clusters with
-https://helm.sh[Helm].
+https://helm.sh[Helm] (hosted at [helmcharts.gruntwork.io](https://github.com/gruntwork-io/helmcharts)).
 
 image::/_docs/k8s-service-architecture.png?raw=true[K8S Service architecture]
 


### PR DESCRIPTION
How to download the charts are no longer visible after the recent README updates, so added back in a link to `helmcharts.gruntwork.io` at the top.