### PR TITLE
Remove --save on helm package since it was removed in helm 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
               # Update version tag
               sed -i "s/0.0.1-replace/${version_tag}/" "${chart}/Chart.yaml"
               # TODO: Figure out provenance strategy
-              (cd "charts" && helm package "${chart_name}" -d "${assets_dir}" --save=false)
+              (cd "charts" && helm package "${chart_name}" -d "${assets_dir}")
             done
 
       - run:


### PR DESCRIPTION
The deploy script failed on `v0.1.1`, and it was because `--save` is no longer a valid option.