### PR TITLE
Surfacing Additional Pod Labels for user

### DIFF
--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -69,6 +69,9 @@ metadata:
     app.kubernetes.io/name: {{ include "k8s-service.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- range $key, $value := .Values.additionalDeploymentLabels }}
+    {{ $key }}: {{ $value }}
+    {{- end}}
 {{- with .Values.deploymentAnnotations }}
   annotations:
 {{ toYaml . | indent 4 }}
@@ -86,7 +89,9 @@ spec:
         app.kubernetes.io/name: {{ include "k8s-service.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         gruntwork.io/deployment-type: main
-
+        {{- range $key, $value := .Values.additionalPodLabels }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
       {{- with .Values.podAnnotations }}
       annotations:
 {{ toYaml . | indent 8 }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -173,10 +173,23 @@ replicaCount: 1
 # NOTE: This variable is injected directly into the deployment spec.
 deploymentAnnotations: {}
 
+# additionalDeploymentLabels will add the provided map to the labels for the Deployment resource created by this chart.
+# this is in addition to the helm template related labels created by the chart
+# The keys and values are free form, but subject to the limitations of Kubernetes labelling.
+# NOTE: This variable is injected directly into the deployment spec.
+additionalDeploymentLabels: {}
+
 # podAnnotations will add the provided map to the annotations for the Pod resource created by the Deployment.
 # The keys and values are free form, but subject to the limitations of Kubernetes resource annotations.
 # NOTE: This variable is injected directly into the pod spec.
 podAnnotations: {}
+
+# additionalDeploymentLabels will add the provided map to the labels for the Pods created by the deployment resource.
+# this is in addition to the helm template related labels created by the chart
+# The keys and values are free form, but subject to the limitations of Kubernetes labelling.
+# The match labels for the deployment aren't affected by these additional labels
+# NOTE: This variable is injected directly into the deployment spec.
+additionalPodLabels: {}
 
 # minPodsAvailable specifies the minimum number of pods that should be available at any given point in time. This is
 # used to configure a PodDisruptionBudget for the included pod. See

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -715,3 +715,28 @@ func TestK8SServiceMainDeploymentContainersLabeledCorrectly(t *testing.T) {
 	// Ensure a "main" type deployment is properly labeled as such
 	assert.Equal(t, deployment.Spec.Selector.MatchLabels["gruntwork.io/deployment-type"], "main")
 }
+
+func TestK8SServiceDeploymentAddingAdditionalLabels(t *testing.T) {
+	t.Parallel()
+	first_custom_deployment_label_value := "first-custom-value"
+	second_custom_deployment_label_value := "second-custom-value"
+	deployment := renderK8SServiceDeploymentWithSetValues(t,
+		map[string]string{"additionalDeploymentLabels.first-label": first_custom_deployment_label_value,
+			"additionalDeploymentLabels.second-label":second_custom_deployment_label_value})
+
+	assert.Equal(t, deployment.Labels["first-label"], first_custom_deployment_label_value)
+	assert.Equal(t, deployment.Labels["second-label"], second_custom_deployment_label_value)
+}
+
+func TestK8SServicePodAddingAdditionalLabels(t *testing.T) {
+	t.Parallel()
+	first_custom_pod_label_value := "first-custom-value"
+	second_custom_pod_label_value := "second-custom-value"
+	deployment := renderK8SServiceDeploymentWithSetValues(t,
+		map[string]string{"additionalPodLabels.first-label":  first_custom_pod_label_value,
+			"additionalPodLabels.second-label": second_custom_pod_label_value})
+
+	assert.Equal(t, deployment.Spec.Template.Labels["first-label"], first_custom_pod_label_value)
+	assert.Equal(t, deployment.Spec.Template.Labels["second-label"], second_custom_pod_label_value)
+}
+


### PR DESCRIPTION
RE: https://github.com/gruntwork-io/helm-kubernetes-services/issues/74

Added two arguments to the values template and in the deployment to allow a user to add additional labels to their pod and deployment. These are provided by additionalDeploymentLabels:{} and additionalPodLabels:{} that the user can provide a map to the same as the annotations arguments. 

I was contemplating adding something to the matchLabels as well but I felt that might open up a can of worms with the core functionality of the template providing a single deployment so I left that in the end.

The main aim is to allow users to integrate gruntwork templates with other labelling schemes they would be running in their k8s workload as well as the mentioned use case in the issue where labels are required for certain tagging and operational uses by other systems. 

I don't think there should be any reason for compatibility issues for existing users.