### PR TITLE
Deployment strategy

### DIFF
--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -81,6 +81,12 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.deploymentStrategy }}
+{{- if and (eq .Values.deploymentStrategy "RollingUpdate") .Values.rollingUpdate }}
+    rollingUpdate:
+{{ toYaml .Values.rollingUpdate | indent 6 }}
+{{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "k8s-service.name" . }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -168,6 +168,33 @@ canary: {}
 # point in time. For example, setting to 3 will signal Kubernetes (via the Deployment contoller) to maintain 3 pods.
 replicaCount: 1
 
+# deploymentStrategy specifies the strategy used to replace old Pods by new ones. Type can be "RollingUpdate" or
+# "Recreate". "RollingUpdate" is the default value.
+# RollingUpdate: The Deployment updates Pods in a rolling update fashion.
+# Recreate: All existing Pods are killed before new ones are created.
+# 
+# RollingUpdate can be further refined by using the options provided by the rollingUpdate variable.
+# The rollingUpdate variable is a map that is directly injected into the deployment spec and it has the following keys:
+#   - Max Unavailable   (Optional) : Field that specifies the maximum number of Pods that can be unavailable
+#                                    during the update process. The value can be an absolute number
+#                                    (for example, 5) or a percentage of desired Pods (for example, 10%).
+#                                    The value cannot be 0 if rollingUpdate.maxSurge is 0. 
+#                                    This option defaults to 25%.
+#   - Max Surge         (Optional) : Field that specifies the maximum number of Pods that can be created over 
+#                                    the desired number of Pods. The value can be an absolute number (for example, 5)
+#                                    or a percentage of desired Pods (for example, 10%). The value cannot be 0 if 
+#                                    MaxUnavailable is 0. 
+#                                    This option defaults to 25%.
+#
+# EXAMPLE: 
+#
+# deploymentStrategy: RollingUpdate
+# rollingUpdate:
+#   maxSurge: 30%
+#   maxUnavailable: 30% 
+deploymentStrategy: RollingUpdate
+rollingUpdate: {}
+
 # deploymentAnnotations will add the provided map to the annotations for the Deployment resource created by this chart.
 # The keys and values are free form, but subject to the limitations of Kubernetes resource annotations.
 # NOTE: This variable is injected directly into the deployment spec.

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -773,3 +773,40 @@ func TestK8SServiceDeploymentAddingPersistentVolumes(t *testing.T) {
 	assert.Equal(t, volName, volume.Name)
 	assert.Equal(t, volClaim, volume.PersistentVolumeClaim.ClaimName)
 }
+
+func TestK8SServiceDeploymentStrategy(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"rollingUpdate.maxSurge":       "30%",
+			"rollingUpdate.maxUnavailable": "20%",
+		},
+	)
+
+	// Confirm that deploymentStrategy is set to RollingUpdate
+	assert.NotNil(t, deployment.Spec.Strategy.RollingUpdate)
+
+	// Confirm that maxSurge and maxUnavailable are equal to values set above
+	rollingUpdateOptions := deployment.Spec.Strategy.RollingUpdate
+
+	assert.Equal(t, rollingUpdateOptions.MaxSurge.String(), "30%")
+	assert.Equal(t, rollingUpdateOptions.MaxUnavailable.String(), "20%")
+}
+
+func TestK8SServiceDeploymentRecreateStrategy(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"deploymentStrategy":           "Recreate",
+			"rollingUpdate.maxSurge":       "30%",
+			"rollingUpdate.maxUnavailable": "20%",
+		},
+	)
+
+	// Confirm that RollingUpdate options are not injected if deployment strategy set to Recreate
+	assert.Nil(t, deployment.Spec.Strategy.RollingUpdate)
+}


### PR DESCRIPTION
Issue #64 

Added support for configuring deployment strategies on the Deployment resource. 
Results from test run are here in this [Gist](https://gist.github.com/MaxKam/b425e096e55eed01fd3d8ddbf83d7727).
Just adding some options so shouldn't be any issues with backwards compatibility. 

Do you want me to add this to the canary deployment and the examples? 