### PR TITLE
add podSecurityContext 

### DIFF
--- a/charts/k8s-service/templates/canarydeployment.yaml
+++ b/charts/k8s-service/templates/canarydeployment.yaml
@@ -108,7 +108,7 @@ spec:
       {{- end }}
       {{- if .Values.podSecurityContext }}
       securityContext:
-      {{ toYaml .Values.podSecurityContext | indent 8 }}
+{{ toYaml .Values.podSecurityContext | indent 8 }}
       {{- end}}
 
       containers:

--- a/charts/k8s-service/templates/canarydeployment.yaml
+++ b/charts/k8s-service/templates/canarydeployment.yaml
@@ -106,7 +106,10 @@ spec:
       {{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
       automountServiceAccountToken : {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- end }}
-      
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.podSecurityContext | indent 8 }}
+      {{- end}}
 
       containers:
         - name: {{ .Values.applicationName }}-canary

--- a/charts/k8s-service/templates/canarydeployment.yaml
+++ b/charts/k8s-service/templates/canarydeployment.yaml
@@ -106,6 +106,7 @@ spec:
       {{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
       automountServiceAccountToken : {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- end }}
+      
 
       containers:
         - name: {{ .Values.applicationName }}-canary

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -106,6 +106,10 @@ spec:
       {{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
       automountServiceAccountToken : {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.podSecurityContext | indent 8 }}
+      {{- end}}
 
       containers:
         - name: {{ .Values.applicationName }}

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -108,7 +108,7 @@ spec:
       {{- end }}
       {{- if .Values.podSecurityContext }}
       securityContext:
-      {{ toYaml .Values.podSecurityContext | indent 8 }}
+{{ toYaml .Values.podSecurityContext | indent 8 }}
       {{- end}}
 
       containers:

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -118,7 +118,6 @@ securityContext: {}
 #More details can be found at https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
 
 # EXAMPLE:
-# 1) To run a container in privilleged mode
 # podSecurityContext:
 #   fsGroup: 2000
 podSecurityContext: {}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -114,6 +114,15 @@ readinessProbe: {}
 #   runAsUser: 2000
 securityContext: {}
 
+#SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty. See type description for default values of each field
+#More details can be found at https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+
+# EXAMPLE:
+# 1) To run a container in privilleged mode
+# podSecurityContext:
+#   fsGroup: 2000
+podSecurityContext: {}
+
 
 # shutdownDelay is the number of seconds to delay the shutdown sequence of the Pod by. This is implemented as a sleep
 # call in the preStop hook. By default, this chart includes a preStop hook with a shutdown delay for eventual

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -114,7 +114,9 @@ readinessProbe: {}
 #   runAsUser: 2000
 securityContext: {}
 
-#SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty. See type description for default values of each field
+#podSecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty. See type description for default values of each field
+#Similar to the securityContext {} however, this sets security attributes at the pod level rather than at the container level scope.
+#This allows certain attributes to be set that are not possible in the container level. For example 'fsGroup'.
 #More details can be found at https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
 
 # EXAMPLE:

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -142,6 +142,23 @@ func TestK8SServiceSecurityContextAnnotationRenderCorrectly(t *testing.T) {
 	assert.Equal(t, *testContainer.SecurityContext.RunAsUser, int64(1000))
 }
 
+func TestK8SServicePodSecurityContextAnnotationRenderCorrectly(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"securityContext.fsGroup": "2000",
+		},
+	)
+	renderedPodSpec := deployment.Spec.Template.Spec
+	assert.Equal(t, len(renderedPodSpec.Volumes), 0)
+	renderedPodContainers := renderedPodSpec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	assert.Equal(t, len(appContainer.Env), 0)
+}
+
 // Test that podAnnotations render correctly to annotate the Pod Template Spec on the Deployment resource
 func TestK8SServicePodAnnotationsRenderCorrectly(t *testing.T) {
 	t.Parallel()

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -148,15 +148,12 @@ func TestK8SServicePodSecurityContextAnnotationRenderCorrectly(t *testing.T) {
 	deployment := renderK8SServiceDeploymentWithSetValues(
 		t,
 		map[string]string{
-			"securityContext.fsGroup": "2000",
+			"podSecurityContext.fsGroup": "2000",
 		},
 	)
 	renderedPodSpec := deployment.Spec.Template.Spec
-	assert.Equal(t, len(renderedPodSpec.Volumes), 0)
-	renderedPodContainers := renderedPodSpec.Containers
-	require.Equal(t, len(renderedPodContainers), 1)
-	appContainer := renderedPodContainers[0]
-	assert.Equal(t, len(appContainer.Env), 0)
+	assert.NotNil(t, renderedPodSpec.SecurityContext)
+	assert.Equal(t, *renderedPodSpec.SecurityContext.fsGroup, int64(2000))
 }
 
 // Test that podAnnotations render correctly to annotate the Pod Template Spec on the Deployment resource


### PR DESCRIPTION
Currently in the chart. The securityContext is only configurable within the container level scope. However, when having a higher level scope of the pod. This is not configurable. 

This PR is to allow configuring the pod level securityContext to be able to set things such as the fsGroup which cannot be set in the container scope but at the pod level. 