### PR TITLE
Update ingress api version

### DIFF
--- a/charts/k8s-service/templates/ingress.yaml
+++ b/charts/k8s-service/templates/ingress.yaml
@@ -12,7 +12,7 @@ We declare some variables defined on the Values. These are reused in `with` and 
 {{- $additionalPathsHigherPriority := .Values.ingress.additionalPathsHigherPriority }}
 {{- $additionalPaths := .Values.ingress.additionalPaths }}
 {{- $servicePort := .Values.ingress.servicePort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Update the ingress api version I was seeing `extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress` in my logs