### PR TITLE
Remove IRSA feature as it leads to user confusion, due to the mutatin…

### DIFF
--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -555,35 +555,6 @@ customResources:
   resources: {}
 
 #----------------------------------------------------------------------------------------------------------------------
-# AWS SPECIFIC VALUES
-# These input values relate to AWS specific features, such as those relating to EKS and the AWS ALB Ingress Controller.
-#----------------------------------------------------------------------------------------------------------------------
-aws:
-  # irsa can be used to configure the projected tokens used in the IAM Roles for Service Accounts feature. This is
-  # useful if you are manually annotating the projected tokens into your Pods, instead of relying on the mutating
-  # admission hook.
-  #
-  # irsa is a map and expects the following keys:
-  #   - role_arn     (string) (required) : The AWS ARN that the Service Account associated with the Pod should assume.
-  #                                        Note that the projected token will not be mounted and the environment
-  #                                        variables will not be set if this is an empty string (the default).
-  #
-  # Note that you can not use any role with the IRSA feature. It must have the proper assume role IAM policy to allow
-  # the Service Account of the Pod to assume that role. See
-  # https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html for more
-  # information.
-  #
-  # EXAMPLE:
-  #
-  # aws:
-  #   irsa:
-  #     role_arn: "arn:aws:iam::123456789012:role/role-for-pod"
-  #
-  irsa:
-    role_arn: ""
-
-
-#----------------------------------------------------------------------------------------------------------------------
 # GOOGLE SPECIFIC VALUES
 # google specifies Google (GKE) specific configuration to be set via arguments/env. variables
 #----------------------------------------------------------------------------------------------------------------------

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -585,59 +585,6 @@ func TestK8SServiceWithContainerCommandHasCommandSpec(t *testing.T) {
 	assert.Equal(t, appContainer.Command, []string{"echo", "Hello world"})
 }
 
-// Test that omitting aws.irsa.role_arn does not render the IRSA vars
-func TestK8SServiceWithoutIRSA(t *testing.T) {
-	t.Parallel()
-
-	deployment := renderK8SServiceDeploymentWithSetValues(
-		t,
-		map[string]string{},
-	)
-	renderedPodSpec := deployment.Spec.Template.Spec
-	assert.Equal(t, len(renderedPodSpec.Volumes), 0)
-	renderedPodContainers := renderedPodSpec.Containers
-	require.Equal(t, len(renderedPodContainers), 1)
-	appContainer := renderedPodContainers[0]
-	assert.Equal(t, len(appContainer.Env), 0)
-}
-
-// Test that setting aws.irsa.role_arn renders the IRSA vars
-func TestK8SServiceWithIRSA(t *testing.T) {
-	t.Parallel()
-
-	testRoleArn := "arn:aws:iam::123456789012:role/test-role"
-	deployment := renderK8SServiceDeploymentWithSetValues(
-		t,
-		map[string]string{
-			"aws.irsa.role_arn": testRoleArn,
-		},
-	)
-	renderedPodSpec := deployment.Spec.Template.Spec
-
-	// Verify projected volume
-	require.Equal(t, len(renderedPodSpec.Volumes), 1)
-	volume := renderedPodSpec.Volumes[0]
-	assert.Equal(t, volume.Name, "aws-iam-token")
-	require.NotNil(t, volume.VolumeSource.Projected)
-	projectedVolume := volume.VolumeSource.Projected
-	require.Equal(t, len(projectedVolume.Sources), 1)
-	projectedVolumeSource := projectedVolume.Sources[0]
-	require.NotNil(t, projectedVolumeSource.ServiceAccountToken)
-	assert.Equal(t, projectedVolumeSource.ServiceAccountToken.Audience, "sts.amazonaws.com")
-
-	// Verify injected env vars
-	renderedPodContainers := renderedPodSpec.Containers
-	require.Equal(t, len(renderedPodContainers), 1)
-	appContainer := renderedPodContainers[0]
-	assert.Equal(t, len(appContainer.Env), 2)
-	roleArnEnv := appContainer.Env[0]
-	assert.Equal(t, roleArnEnv.Name, "AWS_ROLE_ARN")
-	assert.Equal(t, roleArnEnv.Value, testRoleArn)
-	tokenEnv := appContainer.Env[1]
-	assert.Equal(t, tokenEnv.Name, "AWS_WEB_IDENTITY_TOKEN_FILE")
-	assert.Equal(t, tokenEnv.Value, "/var/run/secrets/eks.amazonaws.com/serviceaccount/token")
-}
-
 // Test that providing tls configuration to Ingress renders correctly
 func TestK8SServiceIngressMultiCert(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
…g admission hook

This removes the `aws.irsa` input value and the related features. We originally included it as a way to setup IRSA without the mutating admission hook because EKS originally required deploying the mutating admission hook, but since then it is now included by default so there is no need to manually inject the projected AWS token.

It has led to confusion on several occassions, so will be removing it. Users should transition to using the mutating admission hook, which involves annotating the service account with `eks.amazonaws.com/role-arn`.

---

## Migration guide

This release deprecates the `aws` input value which was originally used for configuring AWS IAM Roles for Service Accounts using manual injection of the projected token (via environment variables and secrets mounting in the Pod). In newer versions of EKS, you can instead rely on the mutating admission hook that comes with every EKS cluster. To use the mutating admission hook, you need to apply the annotation `eks.amazonaws.com/role-arn` on the ServiceAccount.

Since the old approach of manually projecting the tokens is deprecated by AWS, this release removes the manual projection of tokens via the `aws` input value. If you were relying on the `aws.irsa` input value, you must instead switch to using the annotation on the Service Account:

```
serviceAccount:
  name: "my-app"
  create: true
  annotations:
    eks.amazonaws.com/role-arn: "IAM_ROLE_ARN"
```