### PR TITLE
allows for the fullname to be overidden in the values

### DIFF
--- a/charts/k8s-service/templates/_helpers.tpl
+++ b/charts/k8s-service/templates/_helpers.tpl
@@ -14,7 +14,9 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "k8s-service.fullname" -}}
   {{- $name := required "applicationName is required" .Values.applicationName -}}
-  {{- if contains $name .Release.Name -}}
+  {{- if .Values.fullnameOverride -}}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+  {{- else if contains $name .Release.Name -}}
     {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
   {{- else -}}
     {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -585,6 +585,10 @@ customResources:
   enabled: false
   resources: {}
 
+# fullnameOverride is a string that allows overriding the default fullname that appears as the
+# application name and is used as the application name by kubernetes. 
+fullnameOverride: ""
+
 #----------------------------------------------------------------------------------------------------------------------
 # GOOGLE SPECIFIC VALUES
 # google specifies Google (GKE) specific configuration to be set via arguments/env. variables

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -780,3 +780,17 @@ func TestK8SServiceDeploymentRecreateStrategy(t *testing.T) {
 	assert.Equal(t, "Recreate", string(deployment.Spec.Strategy.Type))
 	assert.Nil(t, deployment.Spec.Strategy.RollingUpdate)
 }
+
+func TestK8SServiceFullnameOverride(t *testing.T) {
+	t.Parallel()
+
+	overiddenName := "overidden-name"
+
+	deployment := renderK8SServiceDeploymentWithSetValues(t,
+		map[string]string{
+			"fullnameOverride": overiddenName,
+		},
+	)
+
+	assert.Equal(t, deployment.Name, overiddenName)
+}


### PR DESCRIPTION
There's no current way to explicitly define the fullname that appears in deployments, services, etc.  Given that a user may want this ability, particularly if they are running multiple k8s-services in the same cluster.  This pull request enables users to override the fullname through the `fullnameOverride` key.