### PR TITLE
Adding termination grace period

### DIFF
--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -305,7 +305,7 @@ spec:
 
     {{- /* START TERMINATION GRACE PERIOD LOGIC */ -}}
     {{- if .Values.terminationGracePeriodSeconds }}    
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | 30 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
     {{- end}}
     {{- /* END TERMINATION GRACE PERIOD LOGIC */ -}}
 


### PR DESCRIPTION
Adding the terminationGracePeriodSeconds option to enable configuration for time the pod needs to shut down before deletion.  Explicitly defaults to the standard Kubernetes default of 30 seconds.

Kubernetes API documentation: https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pod-v1-core