### PR TITLE
feat: add support node backed emptyDirs

### DIFF
--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -71,6 +71,9 @@ We need this because certain sections are omitted if there are no volumes or env
 {{- if gt (len .Values.scratchPaths) 0 -}}
   {{- $_ := set $hasInjectionTypes "hasVolume" true -}}
 {{- end -}}
+{{- if gt (len .Values.emptyDirs) 0 -}}
+  {{- $_ := set $hasInjectionTypes "hasVolume" true -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -307,6 +310,10 @@ spec:
             - name: {{ $name }}
               mountPath: {{ quote $value }}
           {{- end }}
+          {{- range $name, $value := .Values.emptyDirs }}
+            - name: {{ $name }}
+              mountPath: {{ quote $value }}
+          {{- end }}
           {{- /* END VOLUME MOUNT LOGIC */ -}}
 
         {{- range $key, $value := .Values.sideCarContainers }}
@@ -379,6 +386,10 @@ spec:
         - name: {{ $name }}
           emptyDir:
             medium: "Memory"
+    {{- end }}
+    {{- range $name, $value := .Values.emptyDirs }}
+        - name: {{ $name }}
+          emptyDir: {}
     {{- end }}
     {{- /* END VOLUME LOGIC */ -}}
 

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -465,6 +465,15 @@ persistentVolumes: {}
 #   example: /mnt/scratch
 scratchPaths: {}
 
+# emptyDirs is a map of key value pairs that specifies which paths in the container should be setup as an emptyDir volume.
+# Under the hood each entry in the map is converted to a volume stored on whatever medium that backs the node
+# (disk, SSD, network storage) and mounted into the container on the path provided as the value.
+#
+# EXAMPLE:
+# emptyDirs:
+#   example: /mnt/example
+emptyDirs: {}
+
 # secrets is a map that specifies the Secret resources that should be exposed to the main application container. Each entry in
 # the map represents a Secret resource. The key refers to the name of the Secret that should be exposed, with the value
 # specifying how to expose the Secret. The value is also a map and has the following attributes:


### PR DESCRIPTION
Resolves #105, adding support for node backed `emptyDirs`. 

I have added the `emptyDirs` input to `values.yaml`, which takes a map of volume name to mount path. 

I used the new input instead of changing the existing `scratchPaths` input to ensure backwards compatibility.

I have configured the template such that each `emptyDir` volume has the configuration:

https://github.com/gruntwork-io/helm-kubernetes-services/blob/91e901bf035871f3df9c388d3504b5c3bfe8d32d/charts/k8s-service/templates/_deployment_spec.tpl#L390-L393

I could also set it up so that the user could pass the emptyDir configuration through themselves as part of the map.