### PR TITLE
Adding termination grace period logic

### DIFF
--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -339,6 +339,12 @@ spec:
     {{- end }}
     {{- /* END IMAGE PULL SECRETS LOGIC */ -}}
 
+    {{- /* START TERMINATION GRACE PERIOD LOGIC */ -}}
+    {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end}}
+    {{- /* END TERMINATION GRACE PERIOD LOGIC */ -}}
+
     {{- /* START VOLUME LOGIC */ -}}
     {{- if index $hasInjectionTypes "hasVolume" }}
       volumes:

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -545,6 +545,14 @@ tolerations: []
 # list is a string that corresponds to the Secret name.
 imagePullSecrets: []
 
+# terminationGracePeriodSeconds sets grace period Kubernetes will wait before terminating the pod. The timeout happens
+# in parallel to preStop hook and the SIGTERM signal, Kubernetes does not wait for preStop to finish before beginning
+# the grace period.
+#
+# EXAMPLE:
+# terminationGracePeriodSeconds: 30
+terminationGracePeriodSeconds: {}
+
 # serviceAccount is a map that configures the ServiceAccount information for the Pod.
 # The expected keys of serviceAccount are:
 #   - name                         (string) : The name of the ServiceAccount in the Namespace where the Pod is deployed

--- a/test/k8s_service_volume_template_test.go
+++ b/test/k8s_service_volume_template_test.go
@@ -8,6 +8,7 @@ package test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -114,4 +115,27 @@ func TestK8SServiceDeploymentAddingEmptyDirs(t *testing.T) {
 	volume := volumes[0]
 	assert.Equal(t, volName, volume.Name)
 	assert.Empty(t, volume.EmptyDir)
+}
+
+func TestK8SServiceDeploymentAddingTerminationGracePeriod(t *testing.T) {
+
+	gracePeriod := "30"
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"terminationGracePeriodSeconds": gracePeriod,
+		},
+	)
+
+	// Verify that there is only one container
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+
+	expectedGracePeriodInt64, err := strconv.ParseInt(gracePeriod, 10, 64)
+
+	// Verify termination grace period has been set for container
+	assert.NoError(t, err)
+	renderedTerminationGracePeriodSeconds := deployment.Spec.Template.Spec.TerminationGracePeriodSeconds
+	require.Equal(t, expectedGracePeriodInt64, *renderedTerminationGracePeriodSeconds)
 }


### PR DESCRIPTION
Adding the terminationGracePeriodSeconds option to enable configuration for time the pod needs to shut down before deletion.

Kubernetes API documentation: https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pod-v1-core

A [PR](https://github.com/gruntwork-io/helm-kubernetes-services/pull/102) of the same changes was raised by [Megan](https://github.com/meganjohn) but as she is now on leave we're unable to updated the original PR. As a consequence we have raised another to cover the original changes and address the comments (update values.yaml and add a template test).

Apologies for the confusion and let me know if there are any issues.

