### PR TITLE
Update CODEOWNERS to reflect latest owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @yorinasub17
-# Team: @bwhaley @robmorgan @autero1
+* @yorinasub17 @bwhaley @rhoboat @zackproser @autero1


### PR DESCRIPTION
NOTE: I originally had the codeowners officially only be me, but have a team section so I know who to route requests to, but in the new world with contractors and team owners, it no longer makes sense to adopt that model so I am officially setting all the current SMEs as code owners.