### PR TITLE
Add support for explicitly setting lifecycle hooks

### DIFF
--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -132,7 +132,32 @@ podSecurityContext: {}
 # consistency reasons. You can read more about why you might want to do this in
 # https://blog.gruntwork.io/delaying-shutdown-to-wait-for-pod-deletion-propagation-445f779a8304
 # You can disable this behavior by setting this value to 0.
+# NOTE: this conflicts with lifecycleHooks.preStop
 shutdownDelay: 5
+
+# lifecycleHooks configures container lifecycle hooks on the Pod so you can run arbitrary commands after the
+# container starts (postStart) or before the container stops.
+# Refer to https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/ for more information on container
+# lifecycles.
+#
+# EXAMPLE:
+#
+# lifecycleHooks:
+#   enabled: true
+#   postStart:
+#     exec:
+#       command:
+#         - echo
+#         - "Run after starting container"
+#   preStop:
+#     exec:
+#       command:
+#         - echo
+#         - "Run before stopping container"
+#
+# NOTE: the preStop hook conflicts with shutdownDelay
+lifecycleHooks:
+  enabled: false
 
 # sideCarContainers specifies any additional containers that should be deployed as side cars to the main application
 # container. This will be included in the Deployment container spec so that it will be included in the application Pod.

--- a/test/k8s_service_lifecycle_hooks_template_test.go
+++ b/test/k8s_service_lifecycle_hooks_template_test.go
@@ -1,0 +1,174 @@
+//go:build all || tpl
+// +build all tpl
+
+// NOTE: We use build flags to differentiate between template tests and integration tests so that you can conveniently
+// run just the template tests. See the test README for more information.
+
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that setting shutdownDelay to 0 will disable the preStop hook
+func TestK8SServiceShutdownDelayZeroDisablesPreStopHook(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(t, map[string]string{"shutdownDelay": "0"})
+
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	assert.Nil(t, appContainer.Lifecycle)
+}
+
+// Test that setting shutdownDelay to something greater than 0 will include a preStop hook
+func TestK8SServiceNonZeroShutdownDelayIncludesPreStopHook(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(t, map[string]string{"shutdownDelay": "5"})
+
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	require.NotNil(t, appContainer.Lifecycle)
+	require.NotNil(t, appContainer.Lifecycle.PreStop)
+	require.NotNil(t, appContainer.Lifecycle.PreStop.Exec)
+	require.Equal(t, appContainer.Lifecycle.PreStop.Exec.Command, []string{"sleep", "5"})
+}
+
+func TestK8SServiceDeploymentAddingOnlyPostStartLifecycleHooks(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			// Disable shutdown delay to ensure it doesn't enable preStop hooks.
+			"shutdownDelay": "0",
+
+			"lifecycleHooks.enabled":                  "true",
+			"lifecycleHooks.postStart.exec.command[0]": "echo",
+			"lifecycleHooks.postStart.exec.command[1]": "run after start",
+		},
+	)
+
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	require.NotNil(t, appContainer.Lifecycle)
+
+	assert.Nil(t, appContainer.Lifecycle.PreStop)
+
+	require.NotNil(t, appContainer.Lifecycle.PostStart)
+	require.NotNil(t, appContainer.Lifecycle.PostStart.Exec)
+	require.Equal(t, appContainer.Lifecycle.PostStart.Exec.Command, []string{"echo", "run after start"})
+}
+
+func TestK8SServiceDeploymentAddingOnlyPreStopLifecycleHooks(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			// Disable shutdown delay to ensure it doesn't enable preStop hooks.
+			"shutdownDelay": "0",
+
+			"lifecycleHooks.enabled":                 "true",
+			"lifecycleHooks.preStop.exec.command[0]": "echo",
+			"lifecycleHooks.preStop.exec.command[1]": "run before stop",
+		},
+	)
+
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	require.NotNil(t, appContainer.Lifecycle)
+
+	assert.Nil(t, appContainer.Lifecycle.PostStart)
+
+	require.NotNil(t, appContainer.Lifecycle.PreStop)
+	require.NotNil(t, appContainer.Lifecycle.PreStop.Exec)
+	require.Equal(t, appContainer.Lifecycle.PreStop.Exec.Command, []string{"echo", "run before stop"})
+}
+
+func TestK8SServiceDeploymentAddingBothLifecycleHooks(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			// Disable shutdown delay to ensure it doesn't enable preStop hooks.
+			"shutdownDelay": "0",
+
+			"lifecycleHooks.enabled":                   "true",
+			"lifecycleHooks.postStart.exec.command[0]": "echo",
+			"lifecycleHooks.postStart.exec.command[1]": "run after start",
+			"lifecycleHooks.preStop.exec.command[0]":   "echo",
+			"lifecycleHooks.preStop.exec.command[1]":   "run before stop",
+		},
+	)
+
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	require.NotNil(t, appContainer.Lifecycle)
+
+	require.NotNil(t, appContainer.Lifecycle.PostStart)
+	require.NotNil(t, appContainer.Lifecycle.PostStart.Exec)
+	require.Equal(t, appContainer.Lifecycle.PostStart.Exec.Command, []string{"echo", "run after start"})
+
+	require.NotNil(t, appContainer.Lifecycle.PreStop)
+	require.NotNil(t, appContainer.Lifecycle.PreStop.Exec)
+	require.Equal(t, appContainer.Lifecycle.PreStop.Exec.Command, []string{"echo", "run before stop"})
+}
+
+func TestK8SServiceDeploymentPreferExplicitPreStopOverShutdownDelay(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"shutdownDelay":                          "5",
+			"lifecycleHooks.enabled":                 "true",
+			"lifecycleHooks.preStop.exec.command[0]": "echo",
+			"lifecycleHooks.preStop.exec.command[1]": "run before stop",
+		},
+	)
+
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	require.NotNil(t, appContainer.Lifecycle)
+
+	assert.Nil(t, appContainer.Lifecycle.PostStart)
+
+	require.NotNil(t, appContainer.Lifecycle.PreStop)
+	require.NotNil(t, appContainer.Lifecycle.PreStop.Exec)
+	require.Equal(t, appContainer.Lifecycle.PreStop.Exec.Command, []string{"echo", "run before stop"})
+}
+
+func TestK8SServiceDeploymentEnabledFalseDisablesLifecycleHooksEvenWhenAddingBoth(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			// Disable shutdown delay to ensure it doesn't enable preStop hooks.
+			"shutdownDelay": "0",
+
+			"lifecycleHooks.enabled":                   "false",
+			"lifecycleHooks.postStart.exec.command[0]": "echo",
+			"lifecycleHooks.postStart.exec.command[1]": "run after start",
+			"lifecycleHooks.preStop.exec.command[0]":   "echo",
+			"lifecycleHooks.preStop.exec.command[1]":   "run before stop",
+		},
+	)
+
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	require.Nil(t, appContainer.Lifecycle)
+}

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -1,3 +1,4 @@
+//go:build all || tpl
 // +build all tpl
 
 // NOTE: We use build flags to differentiate between template tests and integration tests so that you can conveniently
@@ -226,33 +227,6 @@ func TestK8SServiceMultipleImagePullSecrets(t *testing.T) {
 	require.Equal(t, len(renderedImagePullSecrets), 2)
 	assert.Equal(t, renderedImagePullSecrets[0].Name, "docker-private-registry-key")
 	assert.Equal(t, renderedImagePullSecrets[1].Name, "gcr-registry-key")
-}
-
-// Test that setting shutdownDelay to 0 will disable the preStop hook
-func TestK8SServiceShutdownDelayZeroDisablesPreStopHook(t *testing.T) {
-	t.Parallel()
-
-	deployment := renderK8SServiceDeploymentWithSetValues(t, map[string]string{"shutdownDelay": "0"})
-
-	renderedPodContainers := deployment.Spec.Template.Spec.Containers
-	require.Equal(t, len(renderedPodContainers), 1)
-	appContainer := renderedPodContainers[0]
-	assert.Nil(t, appContainer.Lifecycle)
-}
-
-// Test that setting shutdownDelay to something greater than 0 will include a preStop hook
-func TestK8SServiceNonZeroShutdownDelayIncludesPreStopHook(t *testing.T) {
-	t.Parallel()
-
-	deployment := renderK8SServiceDeploymentWithSetValues(t, map[string]string{"shutdownDelay": "5"})
-
-	renderedPodContainers := deployment.Spec.Template.Spec.Containers
-	require.Equal(t, len(renderedPodContainers), 1)
-	appContainer := renderedPodContainers[0]
-	require.NotNil(t, appContainer.Lifecycle)
-	require.NotNil(t, appContainer.Lifecycle.PreStop)
-	require.NotNil(t, appContainer.Lifecycle.PreStop.Exec)
-	require.Equal(t, appContainer.Lifecycle.PreStop.Exec.Command, []string{"sleep", "5"})
 }
 
 // Test that setting additionalPaths on ingress add paths after service path


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://docs.gruntwork.io/guides/contributing/, or
  ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
  Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This adds the ability to configure a custom lifecycle hook on the main application container, in a way that works nicely with the existing `shutdownDelay` input value.

## TODOs

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backwards compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.