### PR TITLE
Add support for service sessionAffinity

### DIFF
--- a/charts/k8s-service/templates/service.yaml
+++ b/charts/k8s-service/templates/service.yaml
@@ -30,4 +30,13 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "k8s-service.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- if .Values.service.sessionAffinityConfig }}
+  {{- with .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig:
+{{ toYaml . | indent 4 }}
+  {{- end}}
+  {{- end}}
+  {{- end}}
 {{- end }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -297,7 +297,28 @@ minPodsAvailable: 0
 #                                       Deployment. This has the same structure as containerPorts, with the additional
 #                                       key of `targetPort` to indicate which port of the container the service port
 #                                       should route to. The `targetPort` can be a name defined in `containerPorts`.
+#   - sessionAffinity (string)        : Used to maintain session affinity, as defined in Kubernetes - supports 'ClientIP' and 'None'
+#                                       (https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies)
+#                                       Kubernetes defaults to None.
+#   - sessionAffinityConfig (object)  : Configuration for session affinity, as defined in Kubernetes
+#                                       (https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies)
 #
+# The following example uses the default config and enables client IP based session affinity with a maximum session
+# sticky time of 3 hours.
+# EXAMPLE:
+# 
+# service:
+#   enabled: true
+#   ports:
+#     app:
+#       port: 80
+#       targetPort: http
+#       protocol: TCP
+#   sessionAffinity: ClientIP
+#   sessionAffinityConfig:
+#     clientIP:
+#       timeoutSeconds: 10800
+# 
 # The default config configures a Service of type ClusterIP with no annotation, and binds port 80 of the pod to the
 # port 80 of the service, and names the binding as `app`:
 service:

--- a/test/k8s_service_template_render_helpers_for_test.go
+++ b/test/k8s_service_template_render_helpers_for_test.go
@@ -126,3 +126,21 @@ func renderK8SServiceAccountWithSetValues(t *testing.T, setValues map[string]str
 	helm.UnmarshalK8SYaml(t, out, &serviceaccount)
 	return serviceaccount
 }
+
+func renderK8SServiceWithSetValues(t *testing.T, setValues map[string]string) corev1.Service {
+	helmChartPath, err := filepath.Abs(filepath.Join("..", "charts", "k8s-service"))
+	require.NoError(t, err)
+
+	// We make sure to pass in the linter_values.yaml values file, which we assume has all the required values defined.
+	options := &helm.Options{
+		ValuesFiles: []string{filepath.Join("..", "charts", "k8s-service", "linter_values.yaml")},
+		SetValues:   setValues,
+	}
+	// Render just the service resource
+	out := helm.RenderTemplate(t, options, helmChartPath, "service", []string{"templates/service.yaml"})
+
+	// Parse the service and return it
+	var service corev1.Service
+	helm.UnmarshalK8SYaml(t, out, &service)
+	return service
+}

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -892,3 +892,33 @@ func TestK8SServiceRenderExtV1Beta1Ingress(t *testing.T) {
 	assert.Equal(t, secondPath.Backend.ServiceName, "black-hole")
 	assert.Equal(t, secondPath.Backend.ServicePort.IntVal, int32(80))
 }
+
+// Test that sessionAffinity and sessionAffinityConfig render correctly when set
+func TestK8SServiceSessionAffinityConfig(t *testing.T) {
+	t.Parallel()
+
+	service := renderK8SServiceWithSetValues(
+		t,
+		map[string]string{
+			"service.sessionAffinity":                               "ClientIP",
+			"service.sessionAffinityConfig.clientIP.timeoutSeconds": "10800",
+		},
+	)
+
+	assert.Equal(t, corev1.ServiceAffinity("ClientIP"), service.Spec.SessionAffinity)
+	assert.Equal(t, int32(10800), *service.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds)
+}
+
+// Test that sessionAffinity and sessionAffinityConfig are not rendered if not set
+func TestK8SServiceSessionAffinityOnlySetIfDefined(t *testing.T) {
+	t.Parallel()
+
+	service := renderK8SServiceWithSetValues(
+		t,
+		map[string]string{},
+	)
+
+	// SessionAffinity and SessionAffinityConfig shouldn't be set
+	assert.Equal(t, corev1.ServiceAffinity(""), service.Spec.SessionAffinity)
+	assert.Nil(t, service.Spec.SessionAffinityConfig)
+}


### PR DESCRIPTION
## Description

This change adds k8s service support for `sessionAffinity` and `sessionAffinityConfig` as defined in Kubernetes ([here](https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies)):

> "If you want to make sure that connections from a particular client are passed to the same Pod each time, you can select the session affinity based on the client's IP addresses by setting service.spec.sessionAffinity to "ClientIP" (the default is "None"). You can also set the maximum session sticky time by setting service.spec.sessionAffinityConfig.clientIP.timeoutSeconds appropriately. (the default value is 10800, which works out to be 3 hours)."

### Documentation

Configuration has been documented in the [values.yaml](https://github.com/gruntwork-io/helm-kubernetes-services/pull/124/files#diff-4383cbf74598517ec7d53efea933a2c3ce702e99254172fd7bfdac025539544b) with a commented example service definition. This should be backwards-compatible since the additional configuration is only included if defined in `.Values.service`.

- `sessionAffinity` : Supports `ClientIP` and `None`. Used to maintain session affinity. Enable client IP based session affinity. Kubernetes defaults to `None`.
- `sessionAffinityConfig` : Configuration object which can contain `clientIP.timeoutSeconds` to specify the seconds of ClientIP session sticky time.

  **Note** : I wasn't sure how to document the type of `sessionAffinityConfig` in `values.yaml` without getting pretty verbose.

#### Example

The following example uses the default config and enables client IP based session affinity with a maximum session sticky time of 3 hours:
```yaml
service:
  enabled: true
  ports:
    app:
      port: 80
      targetPort: http
      protocol: TCP
  sessionAffinity: ClientIP
  sessionAffinityConfig:
    clientIP:
      timeoutSeconds: 10800
```

## TODOs

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backwards compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- [ ] Ensure any 3rd party code adheres with our license policy: https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378
- [ ] _Maintainers Only._ If necessary, release a new version of this repo.
- [ ] _Maintainers Only._ If there were backwards incompatible changes, include a migration guide in the release notes.
- [ ] _Maintainers Only._ Add to the next version of the monthly newsletter (see https://www.notion.so/gruntwork/Monthly-Newsletter-9198cbe7f8914d4abce23dca7b435f43).


## Related Issues
- Fixes #123
