### PR TITLE
Ingress port number type conversion issue

### DIFF
--- a/charts/k8s-service/templates/_capabilities_helpers.tpl
+++ b/charts/k8s-service/templates/_capabilities_helpers.tpl
@@ -21,7 +21,7 @@
               service:
                 name: {{ if .serviceName }}{{ .serviceName }}{{ else }}{{ .fullName }}{{ end }}
                 port:
-                  {{- if kindIs "int64" .servicePort }}
+                  {{- if int .servicePort }}
                   number: {{ .servicePort }}
                   {{- else }}
                   name: {{ .servicePort }}

--- a/test/fixtures/ingress_values_with_name_port.yaml
+++ b/test/fixtures/ingress_values_with_name_port.yaml
@@ -1,0 +1,8 @@
+ingress:
+  enabled: true
+  path: "/app"
+  servicePort: "app"
+  additionalPaths:
+    - path: "/black-hole"
+      serviceName: "black-hole"
+      servicePort: "black-hole"

--- a/test/fixtures/ingress_values_with_number_port.yaml
+++ b/test/fixtures/ingress_values_with_number_port.yaml
@@ -1,0 +1,8 @@
+ingress:
+  enabled: true
+  path: "/app"
+  servicePort: 80
+  additionalPaths:
+    - path: "/black-hole"
+      serviceName: "black-hole"
+      servicePort: 80

--- a/test/k8s_service_template_render_helpers_for_test.go
+++ b/test/k8s_service_template_render_helpers_for_test.go
@@ -1,3 +1,4 @@
+//go:build all || tpl
 // +build all tpl
 
 // NOTE: We use build flags to differentiate between template tests and integration tests so that you can conveniently
@@ -63,6 +64,26 @@ func renderK8SServiceIngressWithSetValues(t *testing.T, setValues map[string]str
 	options := &helm.Options{
 		ValuesFiles: []string{filepath.Join("..", "charts", "k8s-service", "linter_values.yaml")},
 		SetValues:   setValues,
+	}
+	// Render just the ingress resource
+	out := helm.RenderTemplate(t, options, helmChartPath, "ingress", []string{"templates/ingress.yaml"})
+
+	// Parse the ingress and return it
+	var ingress networkingv1.Ingress
+	helm.UnmarshalK8SYaml(t, out, &ingress)
+	return ingress
+}
+
+func renderK8SServiceIngressWithValuesFile(t *testing.T, valuesFilePath string) networkingv1.Ingress {
+	helmChartPath, err := filepath.Abs(filepath.Join("..", "charts", "k8s-service"))
+	require.NoError(t, err)
+
+	// We make sure to pass in the linter_values.yaml values file, which we assume has all the required values defined.
+	options := &helm.Options{
+		ValuesFiles: []string{
+			filepath.Join("..", "charts", "k8s-service", "linter_values.yaml"),
+			valuesFilePath,
+		},
 	}
 	// Render just the ingress resource
 	out := helm.RenderTemplate(t, options, helmChartPath, "ingress", []string{"templates/ingress.yaml"})

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -229,6 +229,46 @@ func TestK8SServiceMultipleImagePullSecrets(t *testing.T) {
 	assert.Equal(t, renderedImagePullSecrets[1].Name, "gcr-registry-key")
 }
 
+func TestK8SServiceIngressPortNumberTypeConversionWithValues(t *testing.T) {
+	t.Parallel()
+
+	ingress := renderK8SServiceIngressWithValuesFile(t, filepath.Join("fixtures", "ingress_values_with_number_port.yaml"))
+	pathRules := ingress.Spec.Rules[0].HTTP.Paths
+	assert.Equal(t, len(pathRules), 2)
+
+	// The first path should be the main service path
+	firstPath := pathRules[0]
+	assert.Equal(t, firstPath.Path, "/app")
+	assert.Equal(t, strings.ToLower(firstPath.Backend.Service.Name), "ingress-linter")
+	assert.Equal(t, firstPath.Backend.Service.Port.Number, int32(80))
+
+	// The second path should be the black hole
+	secondPath := pathRules[1]
+	assert.Equal(t, secondPath.Path, "/black-hole")
+	assert.Equal(t, secondPath.Backend.Service.Name, "black-hole")
+	assert.Equal(t, secondPath.Backend.Service.Port.Number, int32(80))
+}
+
+func TestK8SServiceIngressPortStringTypeConversionWithValues(t *testing.T) {
+	t.Parallel()
+
+	ingress := renderK8SServiceIngressWithValuesFile(t, filepath.Join("fixtures", "ingress_values_with_name_port.yaml"))
+	pathRules := ingress.Spec.Rules[0].HTTP.Paths
+	assert.Equal(t, len(pathRules), 2)
+
+	// The first path should be the main service path
+	firstPath := pathRules[0]
+	assert.Equal(t, firstPath.Path, "/app")
+	assert.Equal(t, strings.ToLower(firstPath.Backend.Service.Name), "ingress-linter")
+	assert.Equal(t, firstPath.Backend.Service.Port.Name, "app")
+
+	// The second path should be the black hole
+	secondPath := pathRules[1]
+	assert.Equal(t, secondPath.Path, "/black-hole")
+	assert.Equal(t, secondPath.Backend.Service.Name, "black-hole")
+	assert.Equal(t, secondPath.Backend.Service.Port.Name, "black-hole")
+}
+
 // Test that setting additionalPaths on ingress add paths after service path
 func TestK8SServiceIngressAdditionalPathsAfterMainServicePath(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR fixes a bug where the number type checking for ingress port expression isn't good enough when passing through a number with `values.yaml`. `helm` seems to coerce numbers into strings when going through a `values.yaml` file, which doesn't happen when using `--set`.

This PR also adds a regression test to make sure we test the path with `values.yaml`.

## Additional note

The regression test expectedly fails without the fix in adc83736d7b09d6332d5350d37dd0fb9d3b783b8 (see build https://app.circleci.com/pipelines/github/gruntwork-io/helm-kubernetes-services/343/workflows/8e969b8a-2c9e-4b1f-819d-e15fb52ff958), but passes after the fix (see https://app.circleci.com/pipelines/github/gruntwork-io/helm-kubernetes-services/344/workflows/a0eeb12e-f372-4005-894b-0e54d3843364)

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
