### PR TITLE
Bump machine and docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
     environment:
       <<: *base_env
     docker:
-      - image: cimg/python:3.10.1
+      - image: "cimg/python:3.10.2"
     steps:
       - checkout
       # Install gruntwork utilities
@@ -85,7 +85,7 @@ jobs:
       # Export go install location to $PATH so it is available in subsequent steps
       - run:
           command: |
-            echo "export PATH=/usr/local/go/bin:$PATH" >> $BASH_ENV
+            echo 'export PATH=/usr/local/go/bin:$PATH' >> $BASH_ENV
       - run:
           <<: *install_helm_client
       # Fail the build if the pre-commit hooks don't pass. Note: if you run pre-commit install locally, these hooks will

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ base_env: &base_env
   GRUNTWORK_INSTALLER_VERSION: v0.0.38
   TERRATEST_LOG_PARSER_VERSION: v0.40.6
   HELM_VERSION: v3.8.0
-  MINIKUBE_VERSION: v1.24.0
+  # Newer versions of minikube has bugs in the nginx ingress setup for k8s <1.19
+  MINIKUBE_VERSION: v1.22.0
   MODULE_CI_VERSION: v0.46.1
   TERRAFORM_VERSION: NONE
   TERRAGRUNT_VERSION: NONE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
     environment:
       <<: *base_env
     docker:
-      - image: circleci/python:3.10.1
+      - image: cimg/python:3.10.1
     steps:
       - checkout
       # Install gruntwork utilities

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,14 @@
 defaults: &defaults
   machine:
     enabled: true
-    image: "ubuntu-1604:201903-01"
+    image: "ubuntu-2004:202111-02"
 
 base_env: &base_env
-  GRUNTWORK_INSTALLER_VERSION: v0.0.21
-  TERRATEST_LOG_PARSER_VERSION: v0.29.0
-  HELM_VERSION: v3.6.3
-  # Newer versions of minikube has bugs in the nginx ingress setup
-  MINIKUBE_VERSION: v1.22.0
-  MODULE_CI_VERSION: v0.40.0
+  GRUNTWORK_INSTALLER_VERSION: v0.0.38
+  TERRATEST_LOG_PARSER_VERSION: v0.40.6
+  HELM_VERSION: v3.8.0
+  MINIKUBE_VERSION: v1.24.0
+  MODULE_CI_VERSION: v0.46.1
   TERRAFORM_VERSION: NONE
   TERRAGRUNT_VERSION: NONE
   PACKER_VERSION: NONE
@@ -77,7 +76,7 @@ jobs:
     environment:
       <<: *base_env
     docker:
-      - image: circleci/python:3.8.1
+      - image: circleci/python:3.10.1
     steps:
       - checkout
       # Install gruntwork utilities

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,9 +5,10 @@ go 1.16
 require (
 	github.com/GoogleCloudPlatform/gke-managed-certs v1.0.5
 	github.com/ghodss/yaml v1.0.0
-	github.com/gruntwork-io/terratest v0.38.6
+	github.com/gruntwork-io/terratest v0.40.6
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.52.1
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/mod v0.4.2
 	k8s.io/api v0.22.3
 	k8s.io/apimachinery v0.22.3
 )

--- a/test/go.sum
+++ b/test/go.sum
@@ -549,8 +549,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/gruntwork-io/go-commons v0.8.0 h1:k/yypwrPqSeYHevLlEDmvmgQzcyTwrlZGRaxEM6G0ro=
 github.com/gruntwork-io/go-commons v0.8.0/go.mod h1:gtp0yTtIBExIZp7vyIV9I0XQkVwiQZze678hvDXof78=
-github.com/gruntwork-io/terratest v0.38.6 h1:0CPrdcSBEXKk/FGFL0XoQ/0/8490Nd0GE5HkvXaPcYc=
-github.com/gruntwork-io/terratest v0.38.6/go.mod h1:qWMjUaGFzoEKjtvgJF1H0igyMLke67Dq0akc9w4PRH8=
+github.com/gruntwork-io/terratest v0.40.6 h1:kBYzD9gcQoruAoV9vmVLk8kjuZAUI5U72h9IAogL/iI=
+github.com/gruntwork-io/terratest v0.40.6/go.mod h1:CjHsEgP1Pe987X5N8K5qEqCuLtu1bqERGIAF8bTj1s0=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -588,8 +588,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hashicorp/terraform-json v0.12.0 h1:8czPgEEWWPROStjkWPUnTQDXmpmZPlkQAwYYLETaTvw=
-github.com/hashicorp/terraform-json v0.12.0/go.mod h1:pmbq9o4EuL43db5+0ogX10Yofv1nozM+wskr/bGFJpI=
+github.com/hashicorp/terraform-json v0.13.0 h1:Li9L+lKD1FO5RVFRM1mMMIBDoUHslOniyEi5CM+FWGY=
+github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9ExU76+cpdY8zHwoazk=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -940,10 +940,10 @@ github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
-github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
-github.com/zclconf/go-cty v1.8.1 h1:SI0LqNeNxAgv2WWqWJMlG2/Ad/6aYJ7IVYYMigmfkuI=
 github.com/zclconf/go-cty v1.8.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty v1.9.1 h1:viqrgQwFl5UpSxc046qblj78wZXVDFnSOufaOTER+cc=
+github.com/zclconf/go-cty v1.9.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/test/k8s_service_nginx_example_test.go
+++ b/test/k8s_service_nginx_example_test.go
@@ -171,7 +171,11 @@ func verifyIngressAvailable(
 
 		// Now hit the service endpoint to verify it is accessible
 		ingress := k8s.GetIngress(t, kubectlOptions, ingressName)
-		ingressEndpoint = ingress.Status.LoadBalancer.Ingress[0].IP
+		if ingress.Status.LoadBalancer.Ingress[0].IP == "" {
+			ingressEndpoint = ingress.Status.LoadBalancer.Ingress[0].Hostname
+		} else {
+			ingressEndpoint = ingress.Status.LoadBalancer.Ingress[0].IP
+		}
 	} else {
 		// Get the ingress and wait until it is available
 		k8s.WaitUntilIngressAvailableV1Beta1(
@@ -184,7 +188,11 @@ func verifyIngressAvailable(
 
 		// Now hit the service endpoint to verify it is accessible
 		ingress := k8s.GetIngressV1Beta1(t, kubectlOptions, ingressName)
-		ingressEndpoint = ingress.Status.LoadBalancer.Ingress[0].IP
+		if ingress.Status.LoadBalancer.Ingress[0].IP == "" {
+			ingressEndpoint = ingress.Status.LoadBalancer.Ingress[0].Hostname
+		} else {
+			ingressEndpoint = ingress.Status.LoadBalancer.Ingress[0].IP
+		}
 	}
 
 	http_helper.HttpGetWithRetryWithCustomValidation(


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This updates the machine image from the deprecated ubuntu 16.04 based image to ubuntu 20.04.
This also updates the docker image from the deprecated `circleci` images to `cimg`.

## TODO
Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
