### PR TITLE
Add ability to deploy image using sha256 digest, not floating label

### DIFF
--- a/charts/k8s-service/README.md
+++ b/charts/k8s-service/README.md
@@ -1008,6 +1008,21 @@ applicationName: nginx
 
 The only difference here is the `tag` of the `containerImage`.
 
+If you wish to upgrade your `nginx` version to a specific `sha256:` image digest value (not image id), then you can do this by
+using the sha256 value instead of the tag label as shown below:
+
+```yaml
+containerImage:
+  repository: nginx
+  tag: sha256:15b5f7f28672bbbf26f058928b16ecb465843845fafe5ea9a06b05a590709150
+
+applicationName: nginx
+```
+
+This will deploy a specific image version, not a tag that could potentially float (like `latest`). This is very useful if doing
+promotion pipelines where you want the values SBOM (Software Bill Of Materials) to represent a specific image version, not
+a label that may no longer refer to the original image version.  
+
 Next, we will upgrade our release using the updated values. To do so, we will use the `helm upgrade` command:
 
 ```bash

--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -146,13 +146,21 @@ spec:
         - name: {{ .Values.applicationName }}-canary
           {{- $repo := required ".Values.canary.containerImage.repository is required" .Values.canary.containerImage.repository }}
           {{- $tag := required ".Values.canary.containerImage.tag is required" .Values.canary.containerImage.tag }}
+          {{- if eq (substr 0 7 $tag) "sha256:" }}
+          image: "{{ $repo }}@{{ $tag }}"
+          {{- else }}
           image: "{{ $repo }}:{{ $tag }}"
+          {{- end }}          
           imagePullPolicy: {{ .Values.canary.containerImage.pullPolicy | default "IfNotPresent" }}
         {{- else }}
         - name: {{ .Values.applicationName }}
           {{- $repo := required ".Values.containerImage.repository is required" .Values.containerImage.repository }}
           {{- $tag := required ".Values.containerImage.tag is required" .Values.containerImage.tag }}
+          {{- if eq (substr 0 7 $tag) "sha256:" }}
+          image: "{{ $repo }}@{{ $tag }}"
+          {{- else }}
           image: "{{ $repo }}:{{ $tag }}"
+          {{- end }}          
           imagePullPolicy: {{ .Values.containerImage.pullPolicy | default "IfNotPresent" }}
         {{- end }}
           {{- if .Values.containerCommand }}


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

This change is to allow the `containerImage.tag` key to support both SHA256 digest image values as well as standard tag labels like `master` or `latest`.

When a SHA256 value is specified, then the `_deployment_spec.tpl` will generate an image line like...

`image: "nginx@sha256:15b5f7f28672bbbf26f058928b16ecb465843845fafe5ea9a06b05a590709150"`

rather than...

`image: "nginx:latest"`

The change is fully backward compatible with existing tag usage.

Tested by running the "-tag tpl" go test scripts, plus the following...

```console
% helm template . --set-string containerImage.repository=fred,containerImage.tag=sha256:15b5f7f28672bbbf26f058928b16ecb465843845fafe5ea9a06b05a590709150,applicationName=fred,canary.enabled=true,canary.containerImage.repository=fredx,canary.containerImage.tag=sha256:15b5f7f28672bbbf26f058928b16ecb465843845fafe5ea9a06b05a590709150 > run1.txt

% helm template . --set-string containerImage.repository=fred,containerImage.tag=latest,applicationName=fred,canary.enabled=true,canary.containerImage.repository=fredx,canary.containerImage.tag=latest > run2.txt
```
[run1.txt](https://github.com/gruntwork-io/helm-kubernetes-services/files/8661363/run1.txt)
[run2.txt](https://github.com/gruntwork-io/helm-kubernetes-services/files/8661368/run2.txt)

### Documentation

Updates have been made to the `helm-kubernetes-services/charts/k8s-service/README.md` to describe the change and the use-cases that you might want to use it for.

This includes a code snippet on usage.

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues

<!--
  Link to related issues, and issues fixed or partially addressed by this PR.
  e.g. Fixes #1234
  e.g. Addresses #1234
  e.g. Related to #1234
-->
