### PR TITLE
[WIP] Adds Statefulset Support - Issue 136

### DIFF
--- a/charts/k8s-service/README.md
+++ b/charts/k8s-service/README.md
@@ -1,13 +1,13 @@
 # Kubernetes Service Helm Chart
 
 This Helm Chart can be used to deploy your application container under a
-[Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) resource onto your Kubernetes
+[Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) or [Statefulset](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) resource onto your Kubernetes
 cluster. You can use this Helm Chart to run and deploy a long-running container, such as a web service or backend
 microservice. The container will be packaged into
-[Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/) that are managed by the `Deployment`
-controller.
+[Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/) that are managed by either the `Deployment` or the `Statefulset`
+controller, depending on which workload you specify.
 
-This Helm Chart can also be used to front the `Pods` of the `Deployment` resource with a
+This Helm Chart can also be used to front the `Pods` of the `Deployment` or `Statefulset` resource with a
 [Service](https://kubernetes.io/docs/concepts/services-networking/service/) to provide a stable endpoint to access the
 `Pods`, as well as load balance traffic to them. The Helm Chart can also specify
 [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) rules to further configure complex routing
@@ -32,8 +32,11 @@ The following resources will be deployed with this Helm Chart, depending on whic
 - `Deployment`: The main `Deployment` controller that will manage the application container image specified in the
                 `containerImage` input value.
 - Secondary `Deployment` for use as canary: An optional `Deployment` controller that will manage a [canary deployment](https://martinfowler.com/bliki/CanaryRelease.html) of the application container image specified in the `canary.containerImage` input value. This is useful for testing a new application tag, in parallel to your stable tag, prior to rolling the new tag out. Created only if you configure the `canary.containerImage` values (and set `canary.enabled = true`).
+- `Statefulset`: The main `Statefulset` controller that will manage the application container image specified in the
+                `containerImage` input value.
+- Secondary `Statefulset` for use as canary: An optional `Statefulset` controller that will manage a [canary deployment](https://martinfowler.com/bliki/CanaryRelease.html) of the application container image specified in the `canary.containerImage` input value. This is useful for testing a new application tag, in parallel to your stable tag, prior to rolling the new tag out. Created only if you configure the `canary.containerImage` values (and set `canary.enabled = true`).
 - `Service`: The `Service` resource providing a stable endpoint that can be used to address to `Pods` created by the
-             `Deployment` controller. Created only if you configure the `service` input (and set
+             `Deployment` or `Statefulset` controller. Created only if you configure the `service` input (and set
              `service.enabled = true`).
 - `ServiceMonitor`: The `ServiceMonitor` describes the set of targets to be monitored by Prometheus. Created only if you configure the service input and set `serviceMonitor.enabled = true`.
 - `Ingress`: The `Ingress` resource providing host and path routing rules to the `Service` for the deployed `Ingress`
@@ -43,10 +46,10 @@ The following resources will be deployed with this Helm Chart, depending on whic
                                 controller, deployment, replica set or stateful set based on observed CPU or memory utilization.
                                 Created only if the user sets `horizontalPodAutoscaler.enabled = true`.
 - `PodDisruptionBudget`: The `PodDisruptionBudget` resource that specifies a disruption budget for the `Pods` managed by
-                         the `Deployment`. This manages how many pods can be disrupted by a voluntary disruption (e.g
+                         the `Deployment` or `Statefulset`. This manages how many pods can be disrupted by a voluntary disruption (e.g
                          node maintenance). Created if you specify a non-zero value for the `minPodsAvailable` input
                          value.
-- `ManagedCertificate`: The `ManagedCertificate` is a [GCP](https://cloud.google.com/) -specific resource that creates a Google Managed SSL certificate. Google-managed SSL certificates are provisioned, renewed, and managed for your domain names. Read more about Google-managed SSL certificates [here](https://cloud.google.com/load-balancing/docs/ssl-certificates#managed-certs). Created only if you configure the `google.managedCertificate` input (and set
+- `ManagedCertificate`: The `ManagedCertificate` is a [GCP](https://cloud.google.com/)-specific resource that creates a Google Managed SSL certificate. Google-managed SSL certificates are provisioned, renewed, and managed for your domain names. Read more about Google-managed SSL certificates [here](https://cloud.google.com/load-balancing/docs/ssl-certificates#managed-certs). Created only if you configure the `google.managedCertificate` input (and set
                          `google.managedCertificate.enabled = true` and `google.managedCertificate.domainName = your.domain.name`).
 
 back to [root README](/README.adoc#core-concepts)

--- a/charts/k8s-service/linter_values.yaml
+++ b/charts/k8s-service/linter_values.yaml
@@ -11,12 +11,6 @@
 # These values are expected to be defined and passed in by the operator when deploying this helm chart.
 #----------------------------------------------------------------------------------------------------------------------
 
-# workloadType defines which type of resource this Helm Chart should deploy.
-# Possible values are: 
-#   - deployment  : Use this to generate a Deployment workload application
-#   - statefulset : Use this to generate a Statefulset workload application
-workloadType: deployment
-
 # containerImage is a map that describes the container image that should be used to serve the application managed by
 # this chart.
 # The expected keys are:

--- a/charts/k8s-service/linter_values.yaml
+++ b/charts/k8s-service/linter_values.yaml
@@ -11,6 +11,12 @@
 # These values are expected to be defined and passed in by the operator when deploying this helm chart.
 #----------------------------------------------------------------------------------------------------------------------
 
+# workloadType defines which type of resource this Helm Chart should deploy.
+# Possible values are: 
+#   - deployment  : Use this to generate a Deployment workload application
+#   - statefulset : Use this to generate a Statefulset workload application
+workloadType: deployment
+
 # containerImage is a map that describes the container image that should be used to serve the application managed by
 # this chart.
 # The expected keys are:

--- a/charts/k8s-service/templates/_statefulset_spec.tpl
+++ b/charts/k8s-service/templates/_statefulset_spec.tpl
@@ -1,0 +1,435 @@
+{{- /*
+Common deployment spec that is shared between the canary and main Statefulset controllers. This template requires 
+the context:
+- Values
+- Release
+- Chart
+- isCanary (a boolean indicating if we are rendering the canary deployment or not)
+You can construct this context using dict:
+(dict "Values" .Values "Release" .Release "Chart" .Chart "isCanary" true)
+*/ -}}
+{{- define "k8s-service.statefulsetSpec" -}}
+{{- /*
+We must decide whether or not there are volumes to inject. The logic to decide whether or not to inject is based on
+whether or not there are configMaps OR secrets that are specified as volume mounts (`as: volume` attributes). We do this
+by using a map to track whether or not we have seen a volume type. We have to use a map because we cannot update a
+variable in helm chart templates.
+
+Similarly, we need to decide whether or not there are environment variables to add
+
+We need this because certain sections are omitted if there are no volumes or environment variables to add.
+*/ -}}
+
+{{/* Go Templates do not support variable updating, so we simulate it using dictionaries */}}
+{{- $hasInjectionTypes := dict "hasVolume" false "hasEnvVars" false "exposePorts" false -}}
+{{- if .Values.envVars -}}
+  {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
+{{- end -}}
+{{- if .Values.additionalContainerEnv -}}
+  {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
+{{- end -}}
+{{- $allContainerPorts := values .Values.containerPorts -}}
+{{- range $allContainerPorts -}}
+  {{/* We are exposing ports if there is at least one key in containerPorts that is not disabled (disabled = false or
+       omitted)
+  */}}
+  {{- if or (not (hasKey . "disabled")) (not .disabled) -}}
+    {{- $_ := set $hasInjectionTypes "exposePorts" true -}}
+  {{- end -}}
+{{- end -}}
+{{- $allSecrets := values .Values.secrets -}}
+{{- range $allSecrets -}}
+  {{- if eq (index . "as") "volume" -}}
+    {{- $_ := set $hasInjectionTypes "hasVolume" true -}}
+  {{- else if eq (index . "as") "environment" -}}
+    {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
+  {{- else if eq (index . "as") "envFrom" }}
+    {{- $_ := set $hasInjectionTypes "hasEnvFrom" true -}}
+  {{- else if eq (index . "as") "none" -}}
+    {{- /* noop */ -}}
+  {{- else -}}
+    {{- fail printf "secrets config has unknown type: %s" (index . "as") -}}
+  {{- end -}}
+{{- end -}}
+{{- $allConfigMaps := values .Values.configMaps -}}
+{{- range $allConfigMaps -}}
+  {{- if eq (index . "as") "volume" -}}
+    {{- $_ := set $hasInjectionTypes "hasVolume" true -}}
+  {{- else if eq (index . "as") "environment" -}}
+    {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
+  {{- else if eq (index . "as") "envFrom" }}
+    {{- $_ := set $hasInjectionTypes "hasEnvFrom" true -}}
+  {{- else if eq (index . "as") "none" -}}
+    {{- /* noop */ -}}
+  {{- else -}}
+    {{- fail printf "configMaps config has unknown type: %s" (index . "as") -}}
+  {{- end -}}
+{{- end -}}
+{{- if gt (len .Values.persistentVolumes) 0 -}}
+  {{- $_ := set $hasInjectionTypes "hasVolume" true -}}
+{{- end -}}
+{{- if gt (len .Values.scratchPaths) 0 -}}
+  {{- $_ := set $hasInjectionTypes "hasVolume" true -}}
+{{- end -}}
+{{- if gt (len .Values.emptyDirs) 0 -}}
+  {{- $_ := set $hasInjectionTypes "hasVolume" true -}}
+{{- end -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "k8s-service.fullname" . }}{{ if .isCanary }}-canary{{ end }}
+  labels:
+    # These labels are required by helm. You can read more about required labels in the chart best practices guide:
+    # https://docs.helm.sh/chart_best_practices/#standard-labels
+    helm.sh/chart: {{ include "k8s-service.chart" . }}
+    app.kubernetes.io/name: {{ include "k8s-service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- range $key, $value := .Values.additionalDeploymentLabels }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ if .isCanary }}{{ .Values.canary.replicaCount | default 1 }}{{ else }}{{ .Values.replicaCount }}{{ end }}
+  {{- if .Values.service.name }}
+  serviceName: {{ .Values.service.name }}
+  {{- else }}
+  serviceName: {{ include "k8s-service.fullname" . }}
+  {{- end }}
+{{- if .Values.updateStrategy.enabled  }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+{{- if and (eq .Values.updateStrategy.type "RollingUpdate") .Values.updateStrategy.rollingUpdate }}
+    rollingUpdate:
+{{ toYaml .Values.updateStrategy.rollingUpdate | indent 6 }}
+{{- end }}
+{{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "k8s-service.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .isCanary }}
+      gruntwork.io/deployment-type: canary
+      {{- else }}
+      gruntwork.io/deployment-type: main
+      {{- end }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "k8s-service.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .isCanary }}
+        gruntwork.io/deployment-type: canary
+        {{- else }}
+        gruntwork.io/deployment-type: main
+        {{- end }}
+        {{- range $key, $value := .Values.additionalPodLabels }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+
+      {{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+    spec:
+      {{- if gt (len .Values.serviceAccount.name) 0 }}
+      serviceAccountName: "{{ .Values.serviceAccount.name }}"
+      {{- end }}
+      {{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
+      automountServiceAccountToken : {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+      {{- end}}
+
+      containers:
+        {{- if .isCanary }}
+        - name: {{ .Values.applicationName }}-canary
+          {{- $repo := required ".Values.canary.containerImage.repository is required" .Values.canary.containerImage.repository }}
+          {{- $tag := required ".Values.canary.containerImage.tag is required" .Values.canary.containerImage.tag }}
+          image: "{{ $repo }}:{{ $tag }}"
+          imagePullPolicy: {{ .Values.canary.containerImage.pullPolicy | default "IfNotPresent" }}
+        {{- else }}
+        - name: {{ .Values.applicationName }}
+          {{- $repo := required ".Values.containerImage.repository is required" .Values.containerImage.repository }}
+          {{- $tag := required ".Values.containerImage.tag is required" .Values.containerImage.tag }}
+          image: "{{ $repo }}:{{ $tag }}"
+          imagePullPolicy: {{ .Values.containerImage.pullPolicy | default "IfNotPresent" }}
+        {{- end }}
+          {{- if .Values.containerCommand }}
+          command:
+{{ toYaml .Values.containerCommand | indent 12 }}
+          {{- end }}
+
+          {{- if index $hasInjectionTypes "exposePorts" }}
+          ports:
+            {{- /*
+              NOTE: we check for a disabled flag here so that users of the helm
+              chart can override the default containerPorts. Specifically, defining a new
+              containerPorts in values.yaml will be merged with the default provided by the
+              chart. For example, if the user provides:
+
+                    containerPorts:
+                      app:
+                        port: 8080
+                        protocol: TCP
+
+              Then this is merged with the default and becomes:
+
+                    containerPorts:
+                      app:
+                        port: 8080
+                        protocol: TCP
+                      http:
+                        port: 80
+                        protocol: TCP
+                      https:
+                        port: 443
+                        protocol: TCP
+
+              and so it becomes append as opposed to replace. To handle this,
+              we allow users to explicitly disable predefined ports. So if the user wants to
+              replace the ports with their own, they would provide the following values file:
+
+                    containerPorts:
+                      app:
+                        port: 8080
+                        protocol: TCP
+                      http:
+                        disabled: true
+                      https:
+                        disabled: true
+            */ -}}
+            {{- range $key, $portSpec := .Values.containerPorts }}
+            {{- if not $portSpec.disabled }}
+            - name: {{ $key }}
+              containerPort: {{ int $portSpec.port }}
+              protocol: {{ $portSpec.protocol }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 12 }}
+          {{- end }}
+
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 12 }}
+          {{- end }}
+          {{- if .Values.securityContext }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
+          {{- end}}
+          resources:
+{{ toYaml .Values.containerResources | indent 12 }}
+
+          {{- if or .Values.lifecycleHooks.enabled (gt (int .Values.shutdownDelay) 0) }}
+          lifecycle:
+            {{- if and .Values.lifecycleHooks.enabled .Values.lifecycleHooks.postStart }}
+            postStart:
+{{ toYaml .Values.lifecycleHooks.postStart | indent 14 }}
+            {{- end }}
+
+            {{- if and .Values.lifecycleHooks.enabled .Values.lifecycleHooks.preStop }}
+            preStop:
+{{ toYaml .Values.lifecycleHooks.preStop | indent 14 }}
+            {{- else if gt (int .Values.shutdownDelay) 0 }}
+            # Include a preStop hook with a shutdown delay for eventual consistency reasons.
+            # See https://blog.gruntwork.io/delaying-shutdown-to-wait-for-pod-deletion-propagation-445f779a8304
+            preStop:
+              exec:
+                command:
+                  - sleep
+                  - "{{ int .Values.shutdownDelay }}"
+            {{- end }}
+
+          {{- end }}
+
+          {{- /* START ENV VAR LOGIC */ -}}
+          {{- if index $hasInjectionTypes "hasEnvVars" }}
+          env:
+          {{- end }}
+          {{- range $key, $value := .Values.envVars }}
+            - name: {{ $key }}
+              value: {{ quote $value }}
+          {{- end }}
+          {{- if .Values.additionalContainerEnv }}
+{{ toYaml .Values.additionalContainerEnv | indent 12 }}
+          {{- end }}
+          {{- range $name, $value := .Values.configMaps }}
+            {{- if eq $value.as "environment" }}
+            {{- range $configKey, $keyEnvVarConfig := $value.items }}
+            - name: {{ required "envVarName is required on configMaps items when using environment" $keyEnvVarConfig.envVarName | quote }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $name }}
+                  key: {{ $configKey }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- range $name, $value := .Values.secrets }}
+            {{- if eq $value.as "environment" }}
+            {{- range $secretKey, $keyEnvVarConfig := $value.items }}
+            - name: {{ required "envVarName is required on secrets items when using environment" $keyEnvVarConfig.envVarName | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $name }}
+                  key: {{ $secretKey }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if index $hasInjectionTypes "hasEnvFrom" }}
+          envFrom:
+          {{- range $name, $value := .Values.configMaps }}
+            {{- if eq $value.as "envFrom" }}
+            - configMapRef:
+                name: {{ $name }}
+            {{- end }}
+          {{- end }}
+          {{- range $name, $value := .Values.secrets }}
+            {{- if eq $value.as "envFrom" }}
+            - secretRef:
+                name: {{ $name }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- /* END ENV VAR LOGIC */ -}}
+
+
+          {{- /* START VOLUME MOUNT LOGIC */ -}}
+          {{- if index $hasInjectionTypes "hasVolume" }}
+          volumeMounts:
+          {{- end }}
+          {{- range $name, $value := .Values.configMaps }}
+            {{- if eq $value.as "volume" }}
+            - name: {{ $name }}-volume
+              mountPath: {{ quote $value.mountPath }}
+              {{- if $value.subPath }}
+              subPath: {{ quote $value.subPath }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- range $name, $value := .Values.secrets }}
+            {{- if eq $value.as "volume" }}
+            - name: {{ $name }}-volume
+              mountPath: {{ quote $value.mountPath }}
+            {{- end }}
+          {{- end }}
+          {{- range $name, $value := .Values.persistentVolumes }}
+            - name: {{ $name }}
+              mountPath: {{ quote $value.mountPath }}
+          {{- end }}
+          {{- range $name, $value := .Values.scratchPaths }}
+            - name: {{ $name }}
+              mountPath: {{ quote $value }}
+          {{- end }}
+          {{- range $name, $value := .Values.emptyDirs }}
+            - name: {{ $name }}
+              mountPath: {{ quote $value }}
+          {{- end }}
+          {{- /* END VOLUME MOUNT LOGIC */ -}}
+
+        {{- range $key, $value := .Values.sideCarContainers }}
+        - name: {{ $key }}
+{{ toYaml $value | indent 10 }}
+        {{- end }}
+
+
+    {{- if gt (len .Values.initContainers) 0 }}
+      initContainers:
+        {{- range $key, $value := .Values.initContainers }}
+        - name: {{ $key }}
+{{ toYaml $value | indent 10 }}
+        {{- end }}
+    {{- end }}
+
+    {{- /* START IMAGE PULL SECRETS LOGIC */ -}}
+    {{- if gt (len .Values.imagePullSecrets) 0 }}
+      imagePullSecrets:
+        {{- range $secretName := .Values.imagePullSecrets }}
+        - name: {{ $secretName }}
+        {{- end }}
+    {{- end }}
+    {{- /* END IMAGE PULL SECRETS LOGIC */ -}}
+
+    {{- /* START TERMINATION GRACE PERIOD LOGIC */ -}}
+    {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- end}}
+    {{- /* END TERMINATION GRACE PERIOD LOGIC */ -}}
+
+    {{- /* START VOLUME LOGIC */ -}}
+    {{- if index $hasInjectionTypes "hasVolume" }}
+      volumes:
+    {{- end }}
+    {{- range $name, $value := .Values.configMaps }}
+      {{- if eq $value.as "volume" }}
+        - name: {{ $name }}-volume
+          configMap:
+            name: {{ $name }}
+            {{- if $value.items }}
+            items:
+              {{- range $configKey, $keyMountConfig := $value.items }}
+              - key: {{ $configKey }}
+                path: {{ required "filePath is required for configMap items" $keyMountConfig.filePath | quote }}
+                {{- if $keyMountConfig.fileMode }}
+                mode: {{ include "k8s-service.fileModeOctalToDecimal" $keyMountConfig.fileMode }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- range $name, $value := .Values.secrets }}
+      {{- if eq $value.as "volume" }}
+        - name: {{ $name }}-volume
+          secret:
+            secretName: {{ $name }}
+            {{- if $value.items }}
+            items:
+              {{- range $secretKey, $keyMountConfig := $value.items }}
+              - key: {{ $secretKey }}
+                path: {{ required "filePath is required for secrets items" $keyMountConfig.filePath | quote }}
+                {{- if $keyMountConfig.fileMode }}
+                mode: {{ include "k8s-service.fileModeOctalToDecimal" $keyMountConfig.fileMode }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- range $name, $value := .Values.persistentVolumes }}
+        - name: {{ $name }}
+          persistentVolumeClaim:
+            claimName: {{ $value.claimName }}
+    {{- end }}
+    {{- range $name, $value := .Values.scratchPaths }}
+        - name: {{ $name }}
+          emptyDir:
+            medium: "Memory"
+    {{- end }}
+    {{- range $name, $value := .Values.emptyDirs }}
+        - name: {{ $name }}
+          emptyDir: {}
+    {{- end }}
+    {{- /* END VOLUME LOGIC */ -}}
+
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end -}}

--- a/charts/k8s-service/templates/canarydeployment.yaml
+++ b/charts/k8s-service/templates/canarydeployment.yaml
@@ -4,6 +4,8 @@ of only the canary Pod(s) backing your application. It is intended to be used to
 and ensure they are free of issues prior to performing a full roll out.
 */ -}}
 
+{{- if eq .Values.workloadType "deployment" -}}
 {{- if .Values.canary.enabled -}}
 {{ include "k8s-service.deploymentSpec" (dict "Values" .Values "isCanary" true "Release" .Release "Chart" .Chart) }}
+{{- end }}
 {{- end }}

--- a/charts/k8s-service/templates/canarystatefulset.yaml
+++ b/charts/k8s-service/templates/canarystatefulset.yaml
@@ -1,0 +1,11 @@
+{{- /*
+The Canary Statefulset Controller for the application being deployed. This resource manages the creation and replacement
+of only the canary Pod(s) backing your application. It is intended to be used to test new release candidates
+and ensure they are free of issues prior to performing a full roll out.
+*/ -}}
+
+{{- if eq .Values.workloadType "statefulset" -}}
+{{- if .Values.canary.enabled -}}
+{{ include "k8s-service.statefulsetSpec" (dict "Values" .Values "isCanary" true "Release" .Release "Chart" .Chart) }}
+{{- end }}
+{{- end }}

--- a/charts/k8s-service/templates/deployment.yaml
+++ b/charts/k8s-service/templates/deployment.yaml
@@ -2,4 +2,6 @@
 The main Deployment Controller for the application being deployed. This resource manages the creation and replacement
 of the Pods backing your application.
 */ -}}
+{{- if eq .Values.workloadType "deployment" -}}
 {{ include "k8s-service.deploymentSpec" (dict "Values" .Values "isCanary" false "Release" .Release "Chart" .Chart) }}
+{{- end }}

--- a/charts/k8s-service/templates/service.yaml
+++ b/charts/k8s-service/templates/service.yaml
@@ -6,7 +6,11 @@ stable endpoint that can be routed within the Kubernetes cluster.
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+  {{- else }}
   name: {{ include "k8s-service.fullname" . }}
+  {{- end }}
   labels:
     # These labels are required by helm. You can read more about required labels in the chart best practices guide:
     # https://docs.helm.sh/chart_best_practices/#standard-labels

--- a/charts/k8s-service/templates/statefulset.yaml
+++ b/charts/k8s-service/templates/statefulset.yaml
@@ -1,0 +1,7 @@
+{{- /*
+The main Statefulset Controller for the application being deployed. This resource manages the creation and replacement
+of the Pods backing your application.
+*/ -}}
+{{- if eq .Values.workloadType "statefulset" -}}
+{{ include "k8s-service.statefulsetSpec" (dict "Values" .Values "isCanary" false "Release" .Release "Chart" .Chart) }}
+{{- end }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -9,6 +9,11 @@
 # These values are expected to be defined and passed in by the operator when deploying this helm chart.
 #----------------------------------------------------------------------------------------------------------------------
 
+# workloadType defines which type of resource this Helm Chart should deploy.
+# Possible values are: 
+#   - deployment  : Use this to generate a Deployment workload application
+#   - statefulset : Use this to generate a Statefulset workload application
+
 # containerImage is a map that describes the container image that should be used to serve the application managed by
 # this chart.
 # The expected keys are:
@@ -254,6 +259,30 @@ deploymentStrategy:
   type: RollingUpdate
   rollingUpdate: {}
 
+# updateStrategy specifies the strategy used to replace old Pods by new ones. Type can be "RollingUpdate" or
+# "OnDelete". "RollingUpdate" is the default value.
+# RollingUpdate: Automated, rolling update for the Pods in a StatefulSet.
+# Recreate: The StatefulSet controller will not automatically update the Pods in a StatefulSet. Users must manually delete Pods to cause the controller to create new Pods that reflect modifications made to a StatefulSet's .spec.template.
+#
+# RollingUpdate can be further refined by providing custom rollingUpdate options.
+# The rollingUpdate variable is a map that is directly injected into the statefulset spec and it allows you to specify partitioned rolling updates.
+# If a partition is specified, all Pods with an ordinal that is greater than or equal to the partition will be updated when the StatefulSet's .spec.template is updated. 
+# All Pods with an ordinal that is less than the partition will not be updated, and, even if they are deleted, they will be recreated at the previous version. 
+# If a StatefulSet's .spec.updateStrategy.rollingUpdate.partition is greater than its .spec.replicas, updates to its .spec.template will not be propagated to its Pods. 
+# In most cases you will not need to use a partition, but they are useful if you want to stage an update, roll out a canary, or perform a phased roll out.
+#
+# EXAMPLE:
+#
+# updateStrategy:
+#   enabled: false
+#   type: RollingUpdate
+# 
+# NOTE: This field is only used in `statefulset` workloads.
+updateStrategy:
+  enabled: false
+  type: RollingUpdate
+  rollingUpdate: {}
+
 # deploymentAnnotations will add the provided map to the annotations for the Deployment resource created by this chart.
 # The keys and values are free form, but subject to the limitations of Kubernetes resource annotations.
 # NOTE: This variable is injected directly into the deployment spec.
@@ -302,6 +331,8 @@ minPodsAvailable: 0
 #                                       Kubernetes defaults to None.
 #   - sessionAffinityConfig (object)  : Configuration for session affinity, as defined in Kubernetes
 #                                       (https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies)
+#   - name (required for statefulset  : The name of the service associated with this deployment.
+#           workloads)     
 #
 # The following example uses the default config and enables client IP based session affinity with a maximum session
 # sticky time of 3 hours.

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -9,11 +9,6 @@
 # These values are expected to be defined and passed in by the operator when deploying this helm chart.
 #----------------------------------------------------------------------------------------------------------------------
 
-# workloadType defines which type of resource this Helm Chart should deploy.
-# Possible values are: 
-#   - deployment  : Use this to generate a Deployment workload application
-#   - statefulset : Use this to generate a Statefulset workload application
-
 # containerImage is a map that describes the container image that should be used to serve the application managed by
 # this chart.
 # The expected keys are:
@@ -44,6 +39,12 @@
 # OPTIONAL VALUES
 # These values have defaults, but may be overridden by the operator
 #----------------------------------------------------------------------------------------------------------------------
+
+# workloadType defines which type of resource this Helm Chart should deploy.
+# Possible values are: 
+#   - deployment  : Use this to generate a Deployment workload application
+#   - statefulset : Use this to generate a Statefulset workload application
+workloadType: deployment
 
 # containerCommand is a list of strings that indicate a custom command to run for the container in place of the default
 # configured on the image. Omit to run the default command configured on the image.

--- a/test/fixtures/canary_and_main_statefulset_values.yaml
+++ b/test/fixtures/canary_and_main_statefulset_values.yaml
@@ -1,3 +1,4 @@
+workloadType: statefulset
 containerImage:
     repository: nginx
     tag: 1.14.2

--- a/test/fixtures/canary_and_main_statefulset_values.yaml
+++ b/test/fixtures/canary_and_main_statefulset_values.yaml
@@ -1,0 +1,22 @@
+containerImage:
+    repository: nginx
+    tag: 1.14.2
+    pullPolicy: IfNotPresent
+applicationName: canary-test
+replicaCount: 3
+canary:
+    enabled: true
+    replicaCount: 3
+    containerImage:
+        repository: nginx
+        tag: 1.16.0
+livenessProbe:
+    httpGet:
+        path: /
+        port: http
+readinessProbe:
+    httpGet:
+        path: /
+        port: http
+service:
+    type: NodePort

--- a/test/fixtures/canary_statefulset_values.yaml
+++ b/test/fixtures/canary_statefulset_values.yaml
@@ -1,3 +1,4 @@
+workloadType: statefulset
 canary:
   enabled: true
   replicaCount: 1

--- a/test/fixtures/canary_statefulset_values.yaml
+++ b/test/fixtures/canary_statefulset_values.yaml
@@ -1,0 +1,6 @@
+canary:
+  enabled: true
+  replicaCount: 1
+  containerImage:
+    repository: nginx
+    tag: 1.16.0

--- a/test/k8s_service_canary_statefulset_template_test.go
+++ b/test/k8s_service_canary_statefulset_template_test.go
@@ -1,0 +1,68 @@
+//go:build all || tpl
+// +build all tpl
+
+// NOTE: We use build flags to differentiate between template tests and integration tests so that you can conveniently
+// run just the template tests. See the test README for more information.
+
+package test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that setting canary.enabled = false will cause the helm template to not render the canary Statefulset resource
+func TestK8SServiceCanaryEnabledFalseDoesNotCreateCanaryStatefulset(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs(filepath.Join("..", "charts", "k8s-service"))
+	require.NoError(t, err)
+
+	// We make sure to pass in the linter_values.yaml values file, which we assume has all the required values defined.
+	// We then use SetValues to override all the defaults.
+	options := &helm.Options{
+		ValuesFiles: []string{filepath.Join("..", "charts", "k8s-service", "linter_values.yaml")},
+		SetValues:   map[string]string{"canary.enabled": "false", "workloadType": "statefulset"},
+	}
+	_, err = helm.RenderTemplateE(t, options, helmChartPath, "canary", []string{"templates/canarystatefulset.yaml"})
+	require.Error(t, err)
+}
+
+// Test that configuring a canary statefulset will render to a manifest with a container that is clearly a canary
+func TestK8SServiceCanaryEnabledCreatesCanaryStatefulset(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs(filepath.Join("..", "charts", "k8s-service"))
+	require.NoError(t, err)
+
+	// We make sure to pass in the linter_values.yaml values file, which we assume has all the required values defined.
+	// We then use SetValues to override all the defaults.
+	options := &helm.Options{
+		ValuesFiles: []string{
+			filepath.Join("..", "charts", "k8s-service", "linter_values.yaml"),
+			filepath.Join("fixtures", "canary_statefulset_values.yaml"),
+		},
+		SetValues: map[string]string{"workloadType": "statefulset"},
+	}
+	out := helm.RenderTemplate(t, options, helmChartPath, "canary", []string{"templates/canarystatefulset.yaml"})
+	
+	// We take the output and render it to a map to validate it has created a canary deployment or not
+	rendered := map[string]interface{}{}
+	err = yaml.Unmarshal([]byte(out), &rendered)
+	assert.NoError(t, err)
+	assert.NotEqual(t, 0, len(rendered))
+
+	// Inspect the name of the rendered canary deployment
+	nameField := rendered["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["name"]
+	nameString := fmt.Sprintf("%v", nameField)
+
+	// Ensure the name contains the string "-canary"
+	assert.True(t, strings.Contains(string(nameString), "-canary"))
+}

--- a/test/k8s_service_canary_statefulset_template_test.go
+++ b/test/k8s_service_canary_statefulset_template_test.go
@@ -49,7 +49,6 @@ func TestK8SServiceCanaryEnabledCreatesCanaryStatefulset(t *testing.T) {
 			filepath.Join("..", "charts", "k8s-service", "linter_values.yaml"),
 			filepath.Join("fixtures", "canary_statefulset_values.yaml"),
 		},
-		SetValues: map[string]string{"workloadType": "statefulset"},
 	}
 	out := helm.RenderTemplate(t, options, helmChartPath, "canary", []string{"templates/canarystatefulset.yaml"})
 	

--- a/test/k8s_service_canary_statefulset_test.go
+++ b/test/k8s_service_canary_statefulset_test.go
@@ -48,7 +48,6 @@ func TestK8SServiceCanaryStatefulset(t *testing.T) {
 			filepath.Join("..", "charts", "k8s-service", "linter_values.yaml"),
 			filepath.Join("fixtures", "canary_and_main_statefulset_values.yaml"),
 		},
-		SetValues: map[string]string{"workloadType": "statefulset"},
 	}
 
 	defer helm.Delete(t, options, releaseName, true)

--- a/test/k8s_service_canary_statefulset_test.go
+++ b/test/k8s_service_canary_statefulset_test.go
@@ -1,0 +1,62 @@
+//go:build all || integration
+// +build all integration
+
+// NOTE: We use build flags to differentiate between template tests and integration tests so that you can conveniently
+// run just the template tests. See the test README for more information.
+
+package test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that:
+//
+// 1. Setting the canary.enabled input variable results in canary pods being created
+// 2. The statefulset deployment succeeds without errors
+// 3. The canary pods are correctly labeled with gruntwork.io/deployment-type=canary
+// 4. Enabling canary deployment does not interfere with main deployment. Main pods come up cleanly as well
+// 5. As configured, the canary and main deployments are running separate image tags
+func TestK8SServiceCanaryStatefulset(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs(filepath.Join("..", "charts", "k8s-service"))
+	require.NoError(t, err)
+
+	// Create a test namespace to deploy resources into, to avoid colliding with other tests
+	kubectlOptions := k8s.NewKubectlOptions("", "", "")
+	uniqueID := random.UniqueId()
+	testNamespace := fmt.Sprintf("k8s-service-canary-%s", strings.ToLower(uniqueID))
+	k8s.CreateNamespace(t, kubectlOptions, testNamespace)
+	defer k8s.DeleteNamespace(t, kubectlOptions, testNamespace)
+	kubectlOptions.Namespace = testNamespace
+
+	// Use the values file in the example and deploy the chart in the test namespace
+	// Set a random release name
+	releaseName := fmt.Sprintf("k8s-service-canary-%s", strings.ToLower(uniqueID))
+	options := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		ValuesFiles: []string{
+			filepath.Join("..", "charts", "k8s-service", "linter_values.yaml"),
+			filepath.Join("fixtures", "canary_and_main_statefulset_values.yaml"),
+		},
+		SetValues: map[string]string{"workloadType": "statefulset"},
+	}
+
+	defer helm.Delete(t, options, releaseName, true)
+	helm.Install(t, options, helmChartPath, releaseName)
+
+	// Uses label filters including gruntwork.io/deployment-type=canary to ensure the correct pods were created
+	verifyCanaryAndMainPodsCreatedSuccessfully(t, kubectlOptions, "canary-test", releaseName)
+	verifyAllPodsAvailable(t, kubectlOptions, "canary-test", releaseName, nginxValidationFunction)
+	verifyDifferentContainerTagsForCanaryPods(t, kubectlOptions, releaseName)
+	verifyServiceRoutesToMainAndCanaryPods(t, kubectlOptions, "canary-test", releaseName)
+}


### PR DESCRIPTION
## Description

Adds support for statefulset deployments.

This pull request introduces the following changes:
  - Adds an optional field called `workloadType` to `values.yaml`, where the default value is `deployment` but `statefulset` is also an option. 
  - Adds a `_statefulset_spec.tpl` template which gets used when `workloadType` is set to `statefulset`. In turn, `_deployment_spec_tpl` only gets used when `workloadType` is set to `deployment`. 
  - Add an optional `updateStrategy` field to `values.yaml` which gets injected into `updateStrategy` on `statefulset` workloads (`workloadType: statefulset`). `deploymentStrategy` continues getting injected into `strategy` on `deployment` workloads.  
  - Add an optional `name` field under `service` due to Statefulset workload requirements. `service` could still have `enabled: false` if the service resource is created outside of the chart.

None of these changes are breaking, as statefulset support is optional and off-by-default. Pre-existing charts should be able to use this version without encountering issues. Similarly, I don't expect any downtime from the changes. 

### Documentation

I have updated the README in `/charts/k8s-service` to indicate that statefulsets are also deployable by the chart. I have also added proper documentation on each field that was added/edited in the chart's `values.yaml`.

I have also added three tests that test the correctness of `statefulset` canary deployments, similar to how `deployment` workloads are tested. You can find the output here: https://gist.github.com/rvc-mf/c2c4c82713cd8da4a95a3bf079d43cb4

Furthermore, I have successfully deployed several statefulset applications using these changes (previously made in a "private" fork) in other projects.

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.


## Related Issues
  Addresses #136 