### PR TITLE
Added support for configuring cluster ip on service

### DIFF
--- a/charts/k8s-service/templates/service.yaml
+++ b/charts/k8s-service/templates/service.yaml
@@ -27,6 +27,9 @@ spec:
     - name: {{ $key }}
 {{ toYaml $value | indent 6 }}
     {{- end }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "k8s-service.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -297,6 +297,7 @@ minPodsAvailable: 0
 #                                       Deployment. This has the same structure as containerPorts, with the additional
 #                                       key of `targetPort` to indicate which port of the container the service port
 #                                       should route to. The `targetPort` can be a name defined in `containerPorts`.
+#   - clusterIP   (string)            : The IP to use as the ClusterIP.
 #   - sessionAffinity (string)        : Used to maintain session affinity, as defined in Kubernetes - supports 'ClientIP' and 'None'
 #                                       (https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies)
 #                                       Kubernetes defaults to None.
@@ -306,7 +307,7 @@ minPodsAvailable: 0
 # The following example uses the default config and enables client IP based session affinity with a maximum session
 # sticky time of 3 hours.
 # EXAMPLE:
-# 
+#
 # service:
 #   enabled: true
 #   ports:
@@ -318,7 +319,7 @@ minPodsAvailable: 0
 #   sessionAffinityConfig:
 #     clientIP:
 #       timeoutSeconds: 10800
-# 
+#
 # The default config configures a Service of type ClusterIP with no annotation, and binds port 80 of the pod to the
 # port 80 of the service, and names the binding as `app`:
 service:

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -962,3 +962,30 @@ func TestK8SServiceSessionAffinityOnlySetIfDefined(t *testing.T) {
 	assert.Equal(t, corev1.ServiceAffinity(""), service.Spec.SessionAffinity)
 	assert.Nil(t, service.Spec.SessionAffinityConfig)
 }
+
+// Test that clusterIP is rendered correctly when it is set.
+func TestK8SServiceClusterIP(t *testing.T) {
+	t.Parallel()
+
+	testCases := []string{
+		// Unset
+		"",
+		// headless service:
+		// https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
+		"None",
+		// Some random IP
+		"192.168.0.42",
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			values := make(map[string]string)
+			if tc != "" {
+				values["service.clusterIP"] = tc
+			}
+
+			service := renderK8SServiceWithSetValues(t, values)
+			assert.Equal(t, tc, service.Spec.ClusterIP)
+		})
+	}
+}

--- a/test/k8s_service_volume_test.go
+++ b/test/k8s_service_volume_test.go
@@ -1,3 +1,4 @@
+//go:build all || integration
 // +build all integration
 
 // NOTE: We use build flags to differentiate between template tests and integration tests so that you can conveniently
@@ -60,5 +61,5 @@ func TestK8SServiceScratchSpaceIsTmpfs(t *testing.T) {
 	pod := pods[0]
 	logs, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "logs", pod.Name)
 	require.NoError(t, err)
-	require.Contains(t, logs, "tmpfs on /mnt/scratch type tmpfs (rw,relatime)")
+	require.Contains(t, logs, "tmpfs on /mnt/scratch type tmpfs (rw,relatime,inode64)")
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Title saids it all

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added support for configuring cluster ip on service. This will allow you to configure a [headless Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services).