### PR TITLE
Allow custom args on deployment spec

### DIFF
--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -159,7 +159,10 @@ spec:
           command:
 {{ toYaml .Values.containerCommand | indent 12 }}
           {{- end }}
-
+          {{- if .Values.containerArgs }}
+          args:
+{{ toYaml .Values.containerArgs | indent 12 }}
+          {{- end }}
           {{- if index $hasInjectionTypes "exposePorts" }}
           ports:
             {{- /*

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -1,3 +1,4 @@
+---
 #----------------------------------------------------------------------------------------------------------------------
 # CHART PARAMETERS
 # This file declares the configuration input values for the k8s-service Helm chart.
@@ -34,7 +35,6 @@
 # applicationName is a string that names the application. This is used to label the pod and to name the main application
 # container in the pod spec. The label is keyed under "gruntwork.io/app-name"
 
-
 #----------------------------------------------------------------------------------------------------------------------
 # OPTIONAL VALUES
 # These values have defaults, but may be overridden by the operator
@@ -49,6 +49,16 @@
 #   - "echo"
 #   - "Hello World"
 containerCommand: null
+
+# containerArgs is a list of strings that indicate custom args that will be passed to the container (CMD) place of the default
+# configured on the image. Omit to use the default args configured in the image
+#
+# Example (run echo "Hello World"):
+#
+# containerArgs:
+#   - "echo"
+#   - "Hello World"
+containerArgs: null
 
 # containerPorts is a map that specifies the ports to open on the container. This is a nested map: the first map lists
 # the named ports, while the second layer lists the port spec. The named references can be used to refer to the specific
@@ -125,7 +135,6 @@ securityContext: {}
 # podSecurityContext:
 #   fsGroup: 2000
 podSecurityContext: {}
-
 
 # shutdownDelay is the number of seconds to delay the shutdown sequence of the Pod by. This is implemented as a sleep
 # call in the preStop hook. By default, this chart includes a preStop hook with a shutdown delay for eventual

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -600,6 +600,34 @@ func TestK8SServiceWithContainerCommandHasCommandSpec(t *testing.T) {
 	assert.Equal(t, appContainer.Command, []string{"echo", "Hello world"})
 }
 
+// Test that omitting containerArgs does not set args attribute on the Deployment container spec.
+func TestK8SServiceDefaultHasNullArgSpec(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(t, map[string]string{})
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	assert.Nil(t, appContainer.Args)
+}
+
+// Test that setting containerCommand sets the command attribute on the Deployment container spec.
+func TestK8SServiceWithContainerArgsHasArgsSpec(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"containerArgs[0]": "echo",
+			"containerArgs[1]": "Hello world",
+		},
+	)
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	assert.Equal(t, appContainer.Args, []string{"echo", "Hello world"})
+}
+
 // Test that providing tls configuration to Ingress renders correctly
 func TestK8SServiceIngressMultiCert(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Enables support for custom args on deployment spec. The current helm only allows custom commands, making it hard to reuse the image by changing the args only and keeping the command (ENTRYPOINT).
It is supported by Kubernetes, for reference: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#use-environment-variables-to-define-arguments.

Gist with [template tests](https://gist.github.com/thiagosalvatore/e02bb81f610d5003fe5f1382b9487188)

Implements #142 


## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

[X] - Added new input parameter `containerArgs` that can be used to define custom args that should be passed to the deployment spec. It behaves exactly as the `containerCommand`, the only difference is that it will populate the `args` instead of the `command` in the spec.
