### PR TITLE
Expose traffic policy configuration for service

### DIFF
--- a/charts/k8s-service/templates/service.yaml
+++ b/charts/k8s-service/templates/service.yaml
@@ -33,6 +33,12 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "k8s-service.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end}}
+  {{- if .Values.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy }}
+  {{- end}}
   {{- if .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   {{- if .Values.service.sessionAffinityConfig }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -325,6 +325,8 @@ minPodsAvailable: 0
 #       targetPort: http
 #       protocol: TCP
 #   sessionAffinity: ClientIP
+#   externalTrafficPolicy: Cluster
+#   internalTrafficPolicy: Cluster
 #   sessionAffinityConfig:
 #     clientIP:
 #       timeoutSeconds: 10800

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -312,6 +312,10 @@ minPodsAvailable: 0
 #                                       Kubernetes defaults to None.
 #   - sessionAffinityConfig (object)  : Configuration for session affinity, as defined in Kubernetes
 #                                       (https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies)
+#   - externalTrafficPolicy (string)  : Configuration to control traffic flow from external sources - supports 'Cluster' and 'Local'
+#                                       https://kubernetes.io/docs/concepts/services-networking/service/#external-traffic-policy
+#   - internalTrafficPolicy (string)  : Configuration to control traffic flow from internal sources - supports 'Cluster' and 'Local'
+#                                       https://kubernetes.io/docs/concepts/services-networking/service/#internal-traffic-policy
 #
 # The following example uses the default config and enables client IP based session affinity with a maximum session
 # sticky time of 3 hours.

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -977,6 +977,34 @@ func TestK8SServiceSessionAffinityConfig(t *testing.T) {
 	assert.Equal(t, int32(10800), *service.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds)
 }
 
+// Test that externalTrafficPolicy is correctly set
+func TestK8SServiceExternalTrafficPolicy(t *testing.T) {
+	t.Parallel()
+
+	service := renderK8SServiceWithSetValues(
+		t,
+		map[string]string{
+			"service.externalTrafficPolicy": "Local",
+		},
+	)
+
+	assert.Equal(t, corev1.ServiceExternalTrafficPolicyType("Local"), service.Spec.ExternalTrafficPolicy)
+}
+
+// Test that internalTrafficPolicy is correctly set
+func TestK8SServiceInternalTrafficPolicy(t *testing.T) {
+	t.Parallel()
+
+	service := renderK8SServiceWithSetValues(
+		t,
+		map[string]string{
+			"service.internalTrafficPolicy": "Local",
+		},
+	)
+
+	assert.Equal(t, corev1.ServiceInternalTrafficPolicyType("Local"), *service.Spec.InternalTrafficPolicy)
+}
+
 // Test that sessionAffinity and sessionAffinityConfig are not rendered if not set
 func TestK8SServiceSessionAffinityOnlySetIfDefined(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Update `k8s-service` helm chart to allow configuration of traffic policies for created K8S service

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
