### PR TITLE
Add support for subPath in secrets volumes

### DIFF
--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -314,6 +314,9 @@ spec:
             {{- if eq $value.as "volume" }}
             - name: {{ $name }}-volume
               mountPath: {{ quote $value.mountPath }}
+              {{- if $value.subPath }}
+              subPath: {{ quote $value.subPath }}
+              {{- end }}
             {{- end }}
           {{- end }}
           {{- range $name, $value := .Values.persistentVolumes }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -544,6 +544,10 @@ emptyDirs: {}
 #     : For Secrets mounted as a volume, specify the mount path on the container file system where the secrets will be
 #       available. Required when the Secret is exposed as a volume. Ignored when the Secret is exposed as environment
 #       variables.
+#   - subPath (string)
+#     : For Secrets mounted as a volume, specify the sub path on the volume system where the secret values will be
+#       available.  Optional when the Secret is exposed as a volume. Ignored when the Secret is exposed as
+#       environment variables.
 #   - items (map[SecretItem])
 #     : Specify how each Secret value should be made available. The keys are the key of the Secret that you wish to
 #       configure, while the value is another map that controls how that key should be exposed. Required when the Secret

--- a/test/k8s_service_config_injection_template_test.go
+++ b/test/k8s_service_config_injection_template_test.go
@@ -196,8 +196,8 @@ func TestK8SServiceVolumeConfigMapAddsVolumeAndVolumeMountWithoutSubPathToPod(t 
 }
 
 // Test that setting the `secrets` input value with volume include the volume mount for the secret
-// We test by injecting to configMaps:
-// configMaps:
+// We test by injecting to secrets:
+// secrets:
 //   dbsettings:
 //     as: volume
 //     mountPath: /etc/db
@@ -300,7 +300,7 @@ func TestK8SServiceVolumeSecretAddsVolumeAndVolumeMountWithSubPathToPod(t *testi
 	require.Equal(t, len(renderedPodVolumes), 1)
 	podVolume := renderedPodVolumes[0]
 
-	// Check that the pod volume is a configmap volume
+	// Check that the pod volume is a secret volume
 	assert.Equal(t, podVolume.Name, "dbsettings-volume")
 	require.NotNil(t, podVolume.Secret)
 	assert.Equal(t, podVolume.Secret.SecretName, "dbsettings")

--- a/test/k8s_service_config_injection_template_test.go
+++ b/test/k8s_service_config_injection_template_test.go
@@ -1,3 +1,4 @@
+//go:build all || tpl
 // +build all tpl
 
 // NOTE: We use build flags to differentiate between template tests and integration tests so that you can conveniently
@@ -194,6 +195,44 @@ func TestK8SServiceVolumeConfigMapAddsVolumeAndVolumeMountWithoutSubPathToPod(t 
 	assert.Empty(t, volumeMount.SubPath)
 }
 
+// Test that setting the `secrets` input value with volume include the volume mount for the secret
+// We test by injecting to configMaps:
+// configMaps:
+//   dbsettings:
+//     as: volume
+//     mountPath: /etc/db
+func TestK8SServiceVolumeSecretAddsVolumeAndVolumeMountWithoutSubPathToPod(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"secrets.dbsettings.as":        "volume",
+			"secrets.dbsettings.mountPath": "/etc/db",
+		},
+	)
+
+	// Verify that there is only one container and only one volume
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	renderedPodVolumes := deployment.Spec.Template.Spec.Volumes
+	require.Equal(t, len(renderedPodVolumes), 1)
+	podVolume := renderedPodVolumes[0]
+
+	// Check that the pod volume is a secret volume
+	assert.Equal(t, podVolume.Name, "dbsettings-volume")
+	require.NotNil(t, podVolume.Secret)
+	assert.Equal(t, podVolume.Secret.SecretName, "dbsettings")
+
+	// Check that the pod volume will be mounted
+	require.Equal(t, len(appContainer.VolumeMounts), 1)
+	volumeMount := appContainer.VolumeMounts[0]
+	assert.Equal(t, volumeMount.Name, "dbsettings-volume")
+	assert.Equal(t, volumeMount.MountPath, "/etc/db")
+	assert.Empty(t, volumeMount.SubPath)
+}
+
 // Test that setting the `configMaps` input value with volume include the volume mount and subpath for the config map
 // We test by injecting to configMaps:
 // configMaps:
@@ -225,6 +264,46 @@ func TestK8SServiceVolumeConfigMapAddsVolumeAndVolumeMountWithSubPathToPod(t *te
 	assert.Equal(t, podVolume.Name, "dbsettings-volume")
 	require.NotNil(t, podVolume.ConfigMap)
 	assert.Equal(t, podVolume.ConfigMap.Name, "dbsettings")
+
+	// Check that the pod volume will be mounted
+	require.Equal(t, len(appContainer.VolumeMounts), 1)
+	volumeMount := appContainer.VolumeMounts[0]
+	assert.Equal(t, volumeMount.Name, "dbsettings-volume")
+	assert.Equal(t, volumeMount.MountPath, "/etc/db/host.txt")
+	assert.Equal(t, volumeMount.SubPath, "host.txt")
+}
+
+// Test that setting the `secrets` input value with volume include the volume mount and subpath for the secret
+// We test by injecting to secrets:
+// secrets:
+//   dbsettings:
+//     as: volume
+//     mountPath: /etc/db/host.txt
+//     subPath: host.xt
+func TestK8SServiceVolumeSecretAddsVolumeAndVolumeMountWithSubPathToPod(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"secrets.dbsettings.as":        "volume",
+			"secrets.dbsettings.mountPath": "/etc/db/host.txt",
+			"secrets.dbsettings.subPath":   "host.txt",
+		},
+	)
+
+	// Verify that there is only one container and only one volume
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	renderedPodVolumes := deployment.Spec.Template.Spec.Volumes
+	require.Equal(t, len(renderedPodVolumes), 1)
+	podVolume := renderedPodVolumes[0]
+
+	// Check that the pod volume is a configmap volume
+	assert.Equal(t, podVolume.Name, "dbsettings-volume")
+	require.NotNil(t, podVolume.Secret)
+	assert.Equal(t, podVolume.Secret.SecretName, "dbsettings")
 
 	// Check that the pod volume will be mounted
 	require.Equal(t, len(appContainer.VolumeMounts), 1)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Add support for subPath in secrets volumes, same way as already possible for configMaps.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
