### PR TITLE
Add support for hostAliases in pod templates

### DIFF
--- a/charts/k8s-service/README.md
+++ b/charts/k8s-service/README.md
@@ -1034,10 +1034,10 @@ To configure a canary deployment, set `canary.enabled = true` and define the `co
 
 ```yaml
 canary:
-  enabled: true
+    enabled: true
     containerImage:
-      repository: nginx
-      tag: 1.15.9
+        repository: nginx
+        tag: 1.15.9
 ```
 Once deployed, your service will route traffic across both your stable and canary deployments, allowing you to monitor for and catch any issues early.
 

--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -140,6 +140,10 @@ spec:
       securityContext:
 {{ toYaml .Values.podSecurityContext | indent 8 }}
       {{- end}}
+      {{- if .Values.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.hostAliases | indent 8 }}
+      {{- end }}
 
       containers:
         {{- if .isCanary }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -110,16 +110,40 @@ livenessProbe: {}
 #     port: http
 readinessProbe: {}
 
-# securityContext is a map that specified the privillege and access control settings for a Pod of Container. Security Context
+# hostAliases is a list of maps that specify additional entries to be added to the pod's `/etc/hosts` file. This is useful
+# for adding custom DNS entries to the pod. The items in the list are maps with the following keys:
+#   - ip        (string)       (required) : The IP address of the host.
+#   - hostnames (list[string]) (required) : A list of hostnames that should be resolved to the IP address.
+#
+# Refer to https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/ for more details.
+#
+# EXAMPLE:
+#
+# The following example specifies two aliases to be added to the pod's /etc/hosts file in a new section at the bottom:
+#
+# hostAliases:
+#   - ip: 127.0.0.1
+#     hostnames:
+#      - foo.local
+#      - bar.local
+#   - ip: 10.1.2.3
+#     hostnames:
+#      - foo.remote
+#      - bar.remote
+#
+# NOTE: This variable is injected directly into the deployment spec.
+hostAliases: []
+
+# securityContext is a map that specified the privilege and access control settings for a Pod of Container. Security Context
 # can be specified when the application requires additional access control permissions. More details on securityContext and supported
 # settings can be found at https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 # similar to the podSecurityContext {} however, this sets security attributes at the container level rather than at the pod level scope.
 
 #
 # EXAMPLE:
-# 1) To run a container in privilleged mode
+# 1) To run a container in privileged mode
 # securityContext:
-#   privilleged: true
+#   privileged: true
 #
 # 2) To run a container as a specific user
 # securityContext:


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds support for `hostAliases`, as per #111 

It was necessary to make the configuration a list, since a map has non-deterministic ordering and order is important in the `/etc/hosts` file.

I also fixed a couple small typos I came across in docs.

Let me know if you want anything changed!

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added support for hostAliases in pod template

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
