### PR TITLE
Add priorityclassname Support and Test

### DIFF
--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -433,7 +433,7 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
 
-        {{- with .Values.priorityClassName }}
+    {{- with .Values.priorityClassName }}
       priorityClassName:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -433,6 +433,11 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
 
+        {{- with .Values.priorityClassName }}
+      priorityClassName:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -637,6 +637,10 @@ containerResources: {}
 nodeSelector: {}
 affinity: {}
 
+# priorityClassName assigns a priorityClass to the deployment allowing pods to preempt or be preempted.
+# See https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
+priorityClassName: {}
+
 # tolerations can be used to allow the pod to be scheduled on nodes with a specific taint.
 # NOTE: This variable is injected directly into the pod spec. See the official documentation for what this might look
 # like: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/

--- a/test/k8s_service_config_injection_template_test.go
+++ b/test/k8s_service_config_injection_template_test.go
@@ -18,6 +18,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// Test that setting the `priorityClassName` input value will include priorityClassName in the pod spec of the deployment
+func TestK8sServicePriorityClassName(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"priorityClassName": "testPriorityClass",
+		},
+	)
+	renderedPriorityClassName := deployment.Spec.Template.Spec.PriorityClassName
+	require.Equal(t, renderedPriorityClassName, "testPriorityClass")
+}
+
 // Test that setting the `envVars` input value to empty object leaves env vars out of the pod.
 func TestK8SServiceEnvVarConfigMapsSecretsEmptyDoesNotAddEnvVarsAndVolumesToPod(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #159.

<!-- Description of the changes introduced by this PR. -->
This PR introduces suport for [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) and adds the `TestK8sServicePriorityClassName` test.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs*.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

*documented in values.yaml. I'm happy to add something to `/charts/k8s-service/README.md` if that is determined to be necessary.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added support for priorityClassName.

