### PR TITLE
Add Support for HPA Scaling Behavior Configuration

### DIFF
--- a/charts/k8s-service/templates/horizontalpodautoscaler.yaml
+++ b/charts/k8s-service/templates/horizontalpodautoscaler.yaml
@@ -28,4 +28,8 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.horizontalPodAutoscaler.avgMemoryUtilization }}
   {{- end }}
+  {{- if .Values.horizontalPodAutoscaler.behavior }}
+  behavior:
+{{ tpl (toYaml .Values.horizontalPodAutoscaler.behavior) $ | indent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -705,12 +705,71 @@ serviceAccount:
 
 # horizontalPodAutoscaler is a map that configures the Horizontal Pod Autoscaler information for this pod
 # The expected keys of hpa are:
-#   - enabled              (bool) : Whether or not Horizontal Pod Autoscaler should be created, if false the
+#   - enabled              (bool)   : Whether or not Horizontal Pod Autoscaler should be created, if false the
 #                                             Horizontal Pod Autoscaler will not be created
-#   - minReplicas          (int)  : The minimum amount of replicas allowed
-#   - maxReplicas          (int)  : The maximum amount of replicas allowed
-#   - avgCpuUtilization    (int)  : The target average CPU utilization to be used with the metrics
-#   - avgMemoryUtilization (int)  : The target average Memory utilization to be used with the metrics
+#   - minReplicas          (int)    : The minimum amount of replicas allowed
+#   - maxReplicas          (int)    : The maximum amount of replicas allowed
+#   - avgCpuUtilization    (int)    : The target average CPU utilization to be used with the metrics
+#   - avgMemoryUtilization (int)    : The target average Memory utilization to be used with the metrics
+#   - behavior             (object) : Configures the scaling behavior of the target in both Up and Down directions 
+#                                     (scaleUp and scaleDown fields respectively). If not set, the default 
+#                                     HPAScalingRules for scale up and scale down are used.
+#                                     Details: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/#HorizontalPodAutoscalerSpec
+# The expected attributes of the "behavior" object are:
+#   - scaleDown            (object) : The scaling policy for scaling Down
+#   - scaleUp              (object) : The scaling policy for scaling Up
+#
+# The expected attributes of both the "scaleDown" and "scaleUp" objects are:
+#   - policies                   (list[object])  : List of potential scaling policies which can be used during 
+#                                                  scaling. At least one policy must be specified, otherwise the 
+#                                                  HPAScalingRules will be discarded as invalid
+#   - selectPolicy               (string)        : Used to specify which policy should be used. If not set, the 
+#                                                  default value MaxPolicySelect is used.
+#   - stabilizationWindowSeconds (int)           : The number of seconds for which past recommendations should be 
+#                                                  considered while scaling up or scaling down. StabilizationWindowSeconds 
+#                                                  must be greater than or equal to zero and less than or equal to 3600 (one hour). 
+#                                                  If not set, use the default values: 
+#                                                    - For scale up: 0 (i.e. no stabilization is done). 
+#                                                    - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+#
+# The expected attributes of the "policies" list for both the "scaleDown" and "scaleUp" objects are:
+#   - periodSeconds           (int)    : Specifies the window of time for which the policy should hold true. PeriodSeconds 
+#                                        must be greater than zero and less than or equal to 1800 (30 min).
+#   - type                    (string) : Used to specify the scaling policy.
+#   - value                   (int)    : The amount of change which is permitted by the policy. It must be greater than zero.
+#
+# Example horizontalPodAutoscaler with "behavior" configuration:
+#
+#  apiVersion: autoscaling/v2
+#  kind: HorizontalPodAutoscaler
+#  metadata:
+#    name: k8s-service-canary-test
+#    namespace: default
+#  spec:
+#    scaleTargetRef:
+#      apiVersion: apps/v1
+#      kind: Deployment
+#      name: k8s-service-canary-test
+#    minReplicas: 1
+#    maxReplicas: 10
+#    behavior:
+#      scaleDown:
+#        policies:
+#        - periodSeconds: 15
+#          type: Percent
+#          value: 100
+#        stabilizationWindowSeconds: 300
+#      scaleUp:
+#        policies:
+#        - periodSeconds: 15
+#          type: Percent
+#          value: 100
+#        - periodSeconds: 15
+#          type: Pods
+#          value: 4
+#        selectPolicy: Max
+#        stabilizationWindowSeconds: 0
+#
 #
 # The default config will not create the Horizontal Pod Autoscaler by setting enabled = false, the default values are
 # set so if enabled is true the horizontalPodAutoscaler has valid values.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #163.

This PR adds configuration support for [HPA Scaling Behavior](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior) configuration.

<!-- Description of the changes introduced by this PR. -->

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
- Added configuration support for HPA Scaling Behavior configuration.

### Migration Guide
Changes are backward compatible.
<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
