### PR TITLE
171 inject Secret Store CSI driver `deployment_spec.tpl`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -41,7 +41,8 @@ toc::[]
 * Deploy your application containers on to Kubernetes
 * Zero-downtime rolling deployments
 * Auto scaling and auto healing
-* Configuration management and Secrets management
+* Configuration management and Secrets management 
+** Secrets as Environment/Volumes/Secret Store CSI
 * Ingress and Service endpoints
 
 

--- a/charts/k8s-service/README.md
+++ b/charts/k8s-service/README.md
@@ -903,17 +903,13 @@ secrets:
   my-secret:
     as: csi
     mountPath: /etc/db
+    readOnly: true
     csi:
       driver: secrets-store.csi.k8s.io
-      readOnly: true
-      volumeAttributes:
-        secretProviderClass: secret-provider-class
+      secretProviderClass: secret-provider-class
     items:
-      - name: ENV_1
-        valueFrom:
-        secretKeyRef:
-          name: my-secret
-          key: ENV_1
+      my-secret:
+        envVarName: SECRET_VAR
 ```
 
 **NOTE**: The volumes are different between `secrets` and `configMaps`. This means that if you use the same `mountPath`

--- a/charts/k8s-service/README.md
+++ b/charts/k8s-service/README.md
@@ -896,12 +896,34 @@ secrets:
         filePath: password
 ```
 
+**Mounting secrets with CSI**: In this example, we mount the `my-secret` `Secret` as the file `/etc/db`, and specify that the secret will sync with Secret Manager store (AWS, GCP, Vault) secret named `my-secret`. We also details the csi block were we define the driver and secreteProviderClass.
+
+```yaml
+secrets:
+  my-secret:
+    as: csi
+    mountPath: /etc/db
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: secret-provider-class
+    items:
+      - name: ENV_1
+        valueFrom:
+        secretKeyRef:
+          name: my-secret
+          key: ENV_1
+```
+
 **NOTE**: The volumes are different between `secrets` and `configMaps`. This means that if you use the same `mountPath`
 for different secrets and config maps, you can end up with only one. It is undefined which `Secret` or `ConfigMap` ends
 up getting mounted. To be safe, use a different `mountPath` for each one.
 
 **NOTE**: If you want mount the volumes created with `secrets` or `configMaps` on your init or sidecar containers, you will 
 have to append `-volume` to the volume name in . In the example above, the resulting volume will be `my-secret-volume`.
+
+**Note** When installing the CSI driver on your cluster you have an option to activate syncing of secrets 
 
 ```yaml
 sideCarContainers:

--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -294,12 +294,12 @@ spec:
             {{- end }}
             {{- end }}
             {{- if eq $value.as "csi" }}
-            {{- range $secretName, $keyEnvVarConfig := $value.items }}
-            - name: {{ required "envVarName is required on secrets items when using environment" $keyEnvVarConfig.name | quote }}
+            {{- range $secretKey, $keyEnvVarConfig := $value.items }}
+            - name: {{ required "envVarName is required on secrets items when using csi" $keyEnvVarConfig.envVarName | quote }}
               valueFrom:
                 secretKeyRef:
                   name: {{ $name }}
-                  key: {{ $keyEnvVarConfig.name }}
+                  key: {{ $secretKey }}
             {{- end }}
             {{- end }}
           {{- end }}
@@ -340,6 +340,9 @@ spec:
               mountPath: {{ quote $value.mountPath }}
               {{- if $value.subPath }}
               subPath: {{ quote $value.subPath }}
+              {{- end }}
+              {{- if eq $value.as "csi" }}
+              readOnly: {{ $value.csi.readOnly }}
               {{- end }}
             {{- end }}
           {{- end }}
@@ -429,7 +432,7 @@ spec:
             readOnly: {{ $value.csi.readOnly }}
             driver:  {{ $value.csi.driver }}
             volumeAttributes:
-              secretProviderClass: {{ $value.csi.volumeAttributes.secretProviderClass }}
+              secretProviderClass: {{ $value.csi.secretProviderClass }}
           
       {{- end }}    
     {{- end }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -597,9 +597,9 @@ emptyDirs: {}
 # secrets is a map that specifies the Secret resources that should be exposed to the main application container. Each entry in
 # the map represents a Secret resource. The key refers to the name of the Secret that should be exposed, with the value
 # specifying how to expose the Secret. The value is also a map and has the following attributes:
-#   - as (enum[volume,environment,envFrom,none]) (required)
+#   - as (enum[volume,environment,envFrom,csi,none]) (required)
 #     : Secrets can be exposed to Pods as a volume mount, or as environment variables. This attribute is a string enum
-#       that is expected to be either "volume", "environment", or "envFrom", specifying that the Secret should be
+#       that is expected to be either "volume", "environment", "envFrom", or "csi" specifying that the Secret should be
 #       exposed as a mounted volume, via environment variables, or loaded in its entirety as environment variables
 #       respectively. This attribute can also be set to "none", which disables the `Secret` on the container.
 #   - mountPath (string)
@@ -624,7 +624,12 @@ emptyDirs: {}
 #                           exposed as environment variables. Expected to be the octal (e.g 777, 644). Defaults to 644.
 #   - envVarName (string) : The name of the environment variable where the value of the Secret keyed at the given key of
 #                           the item should be stored. Ignored when the Secret is exposed as a volume mount.
-#
+#   - csi (map)
+#     : For Secrets exposed as a volume using a CSI driver, specify the CSI driver details. This field should contain the
+#       following attributes:
+#       - driver (string)    : The name of the CSI driver.
+#       - readOnly (boolean) : Specify whether the volume should be mounted read-only.
+#       - secretProviderClass (string) : The name of the SecretProviderClass.
 # NOTE: These secrets are only automatically injected to the main application container. To add them to the side car
 # containers, use the official Kubernetes Pod syntax:
 # https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets
@@ -632,6 +637,9 @@ emptyDirs: {}
 # The following example exposes the Secret `mysecret` as a volume mounted to `/etc/mysecret`, while it exposes the
 # Secret `myothersecret` as an environment variable. Additionally, it automatically mounts all of the keys
 # `anothersecret` as environment variables using the `envFrom` keyword.
+# The following example exposes the Secret `onemoresecret` as a volume mounted to `/mnt/secrets-store-volume`,
+# using the CSI driver `secrets-store.csi.k8s.io`, and configures an environment variable `SECRET_ONEMORESECRET`
+# with the corresponding value from the Secret.
 #
 # EXAMPLE:
 #
@@ -646,6 +654,16 @@ emptyDirs: {}
 #         envVarName: SECRET_FOO
 #   anothersecret:
 #     as: envFrom
+#   onemoresecret:
+#     as: csi
+#     mountPath: /mnt/secrets-store-volume
+#     csi:
+#       driver: secrets-store.csi.k8s.io
+#       readOnly: true
+#       secretProviderClass: mysecretproviderclass
+#     items:
+#       onemoresecret:
+#         envVarName: SECRET_VAR
 secrets: {}
 
 # containerResources specifies the amount of resources the application container will require. Only specify if you have

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -630,6 +630,7 @@ emptyDirs: {}
 #       - driver (string)    : The name of the CSI driver.
 #       - readOnly (boolean) : Specify whether the volume should be mounted read-only.
 #       - secretProviderClass (string) : The name of the SecretProviderClass.
+#   - readOnly (boolean) : Specify whether the volume should be mounted read-only.
 # NOTE: These secrets are only automatically injected to the main application container. To add them to the side car
 # containers, use the official Kubernetes Pod syntax:
 # https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets
@@ -657,9 +658,9 @@ emptyDirs: {}
 #   onemoresecret:
 #     as: csi
 #     mountPath: /mnt/secrets-store-volume
+#     readOnly: true
 #     csi:
 #       driver: secrets-store.csi.k8s.io
-#       readOnly: true
 #       secretProviderClass: mysecretproviderclass
 #     items:
 #       onemoresecret:

--- a/test/k8s_service_config_injection_template_test.go
+++ b/test/k8s_service_config_injection_template_test.go
@@ -464,9 +464,9 @@ func TestK8SServiceCSISecretAddsEnvVarsToPod(t *testing.T) {
 		t,
 		map[string]string{			
 			"secrets.dbsettings.as":                    "csi",
+			"secrets.dbsettings.readOnly":              "true",
 
 			"secrets.dbsettings.csi.driver":              "secrets-store.csi.k8s.io",
-			"secrets.dbsettings.csi.readOnly":            "true",
 			"secrets.dbsettings.csi.secretProviderClass": "secret-provider-class",
 			
 			"secrets.dbsettings.items.host.envVarName": "DB_HOST",

--- a/test/k8s_service_config_injection_template_test.go
+++ b/test/k8s_service_config_injection_template_test.go
@@ -446,6 +446,62 @@ func TestK8SServiceEnvironmentSecretAddsEnvVarsToPod(t *testing.T) {
 	assert.Equal(t, renderedEnvVar["DB_PORT"].ValueFrom.SecretKeyRef.Name, "dbsettings")
 }
 
+// Test that setting the `secrets` input value with environment include those csi vars
+// We test by injecting to secrets:
+// secrets:
+//
+//	dbsettings:
+//	  as: csi
+//	  items:
+//	    host:
+//	      envVarName: DB_HOST
+//	    port:
+//	      envVarName: DB_PORT
+func TestK8SServiceCSISecretAddsEnvVarsToPod(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{			
+			"secrets.dbsettings.as":                    "csi",
+
+			"secrets.dbsettings.csi.driver":              "secrets-store.csi.k8s.io",
+			"secrets.dbsettings.csi.readOnly":            "true",
+			"secrets.dbsettings.csi.secretProviderClass": "secret-provider-class",
+			
+			"secrets.dbsettings.items.host.envVarName": "DB_HOST",
+			"secrets.dbsettings.items.port.envVarName": "DB_PORT",
+		},
+	)
+
+	// Verify that there is only one container and that the environments section is empty.
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	appContainer := renderedPodContainers[0]
+	environments := appContainer.Env
+	assert.Equal(t, len(environments), 2)
+
+	// Read in the configured env vars for convenient mapping of env var name
+	renderedEnvVar := map[string]corev1.EnvVar{}
+	for _, env := range environments {
+		renderedEnvVar[env.Name] = env
+	}
+
+	// Verify the DB_HOST env var comes from secret host key of dbsettings
+	assert.Equal(t, renderedEnvVar["DB_HOST"].Value, "")
+	require.NotNil(t, renderedEnvVar["DB_HOST"].ValueFrom)
+	require.NotNil(t, renderedEnvVar["DB_HOST"].ValueFrom.SecretKeyRef)
+	assert.Equal(t, renderedEnvVar["DB_HOST"].ValueFrom.SecretKeyRef.Key, "host")
+	assert.Equal(t, renderedEnvVar["DB_HOST"].ValueFrom.SecretKeyRef.Name, "dbsettings")
+
+	// Verify the DB_PORT env var comes from secret port key of dbsettings
+	assert.Equal(t, renderedEnvVar["DB_PORT"].Value, "")
+	require.NotNil(t, renderedEnvVar["DB_PORT"].ValueFrom)
+	require.NotNil(t, renderedEnvVar["DB_PORT"].ValueFrom.SecretKeyRef)
+	assert.Equal(t, renderedEnvVar["DB_PORT"].ValueFrom.SecretKeyRef.Key, "port")
+	assert.Equal(t, renderedEnvVar["DB_PORT"].ValueFrom.SecretKeyRef.Name, "dbsettings")
+}
+
 // Test that setting the `secrets` input value with volume include the volume mount for the secret
 // We test by injecting to secrets:
 // secrets:

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -887,6 +887,7 @@ func TestK8SServiceFullnameOverride(t *testing.T) {
 func TestK8SServiceEnvFrom(t *testing.T) {
 	t.Parallel()
 
+	// TODO: this test is failing
 	t.Run("BothConfigMapsAndSecretsEnvFrom", func(t *testing.T) {
 		deployment := renderK8SServiceDeploymentWithSetValues(t,
 			map[string]string{
@@ -913,6 +914,7 @@ func TestK8SServiceEnvFrom(t *testing.T) {
 		assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].EnvFrom[0].ConfigMapRef.Name, "test-configmap")
 	})
 
+	// TODO: this test is failing
 	t.Run("OnlySecretsEnvFrom", func(t *testing.T) {
 		deployment := renderK8SServiceDeploymentWithSetValues(t,
 			map[string]string{
@@ -924,7 +926,6 @@ func TestK8SServiceEnvFrom(t *testing.T) {
 		assert.Equal(t, len(deployment.Spec.Template.Spec.Containers[0].EnvFrom), 1)
 		assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].EnvFrom[0].SecretRef.Name, "test-secret")
 	})
-
 }
 
 func TestK8SServiceMinPodsAvailableZeroMeansNoPDB(t *testing.T) {

--- a/test/k8s_service_template_test.go
+++ b/test/k8s_service_template_test.go
@@ -887,7 +887,6 @@ func TestK8SServiceFullnameOverride(t *testing.T) {
 func TestK8SServiceEnvFrom(t *testing.T) {
 	t.Parallel()
 
-	// TODO: this test is failing
 	t.Run("BothConfigMapsAndSecretsEnvFrom", func(t *testing.T) {
 		deployment := renderK8SServiceDeploymentWithSetValues(t,
 			map[string]string{
@@ -914,7 +913,6 @@ func TestK8SServiceEnvFrom(t *testing.T) {
 		assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].EnvFrom[0].ConfigMapRef.Name, "test-configmap")
 	})
 
-	// TODO: this test is failing
 	t.Run("OnlySecretsEnvFrom", func(t *testing.T) {
 		deployment := renderK8SServiceDeploymentWithSetValues(t,
 			map[string]string{

--- a/test/k8s_service_volume_secret_store_csi_template_test.go
+++ b/test/k8s_service_volume_secret_store_csi_template_test.go
@@ -23,12 +23,10 @@ func TestK8SServiceDeploymentCheckSecretStoreCSIBlock(t *testing.T) {
 	deployment := renderK8SServiceDeploymentWithSetValues(
 		t,
 		map[string]string{
-<<<<<<< HEAD
-			"secrets.dbsettings.as":           "volume",
-=======
-			"serviceAccount.name":             "secret-sa",
-			"secrets.dbsettings.as":           "csi",
->>>>>>> 046a51b (test: check env section is added)
+
+			"serviceAccount.name":   "secret-sa",
+			"secrets.dbsettings.as": "csi",
+
 			"secrets.dbsettings.mountPath":    "/etc/db",
 			"secrets.dbsettings.csi.driver":   "secrets-store.csi.k8s.io",
 			"secrets.dbsettings.csi.readOnly": "true",
@@ -60,7 +58,7 @@ func TestK8SServiceDeploymentCheckSecretStoreCSIBlock(t *testing.T) {
 	assert.Equal(t, podVolume.CSI.Driver, "secrets-store.csi.k8s.io")
 	assert.NotNil(t, podVolume.CSI.VolumeAttributes)
 	assert.Equal(t, podVolume.CSI.VolumeAttributes, map[string]string{
-		"secretProviderClass": "backend-deployment-aws-secrets",
+		"secretProviderClass": "secret-provider-class",
 	})
 
 	// Check that the container env contains the ENV from secrets

--- a/test/k8s_service_volume_secret_store_csi_template_test.go
+++ b/test/k8s_service_volume_secret_store_csi_template_test.go
@@ -23,35 +23,52 @@ func TestK8SServiceDeploymentCheckSecretStoreCSIBlock(t *testing.T) {
 	deployment := renderK8SServiceDeploymentWithSetValues(
 		t,
 		map[string]string{
+<<<<<<< HEAD
 			"secrets.dbsettings.as":           "volume",
+=======
+			"serviceAccount.name":             "secret-sa",
+			"secrets.dbsettings.as":           "csi",
+>>>>>>> 046a51b (test: check env section is added)
 			"secrets.dbsettings.mountPath":    "/etc/db",
 			"secrets.dbsettings.csi.driver":   "secrets-store.csi.k8s.io",
 			"secrets.dbsettings.csi.readOnly": "true",
 
-			"secrets.dbsettings.csi.volumeAttributes.secretProviderClass": "backend-deployment-aws-secrets",
+			"secrets.dbsettings.csi.volumeAttributes.secretProviderClass": "secret-provider-class",
+
+			"secrets.dbsettings.items[0].name":                        "ENV_1",
+			"secrets.dbsettings.items[0].valueFrom.secretKeyRef.name": "dbsettings",
+			"secrets.dbsettings.items[0].valueFrom.secretKeyRef.key":  "ENV_1",
+			"secrets.dbsettings.items[1].name":                        "ENV_2",
+			"secrets.dbsettings.items[1].valueFrom.secretKeyRef.name": "dbsettings",
+			"secrets.dbsettings.items[1].valueFrom.secretKeyRef.key":  "ENV_2",
 		},
 	)
 
 	// Verify that there is only one container and only one volume
 	renderedPodContainers := deployment.Spec.Template.Spec.Containers
 	require.Equal(t, len(renderedPodContainers), 1)
-	// appContainer := renderedPodContainers[0]
+	appContainer := renderedPodContainers[0]
 	renderedPodVolumes := deployment.Spec.Template.Spec.Volumes
 	require.Equal(t, len(renderedPodVolumes), 1)
 	podVolume := renderedPodVolumes[0]
 
 	// Check that the pod volume is a secret volume
 	assert.Equal(t, podVolume.Name, "dbsettings-volume")
-	require.NotNil(t, podVolume.Secret)
-	assert.Equal(t, podVolume.Secret.SecretName, "dbsettings")
 
 	// Check that the pod volume has CSI block
 	require.NotNil(t, podVolume.CSI)
-
 	assert.Equal(t, podVolume.CSI.Driver, "secrets-store.csi.k8s.io")
 	assert.NotNil(t, podVolume.CSI.VolumeAttributes)
 	assert.Equal(t, podVolume.CSI.VolumeAttributes, map[string]string{
 		"secretProviderClass": "backend-deployment-aws-secrets",
 	})
 
+	// Check that the container env contains the ENV from secrets
+	require.NotNil(t, appContainer.Env)
+	assert.Equal(t, appContainer.Env[0].Name, "ENV_1")
+	assert.Equal(t, appContainer.Env[0].ValueFrom.SecretKeyRef.Name, "dbsettings")
+	assert.Equal(t, appContainer.Env[0].ValueFrom.SecretKeyRef.Key, "ENV_1")
+	assert.Equal(t, appContainer.Env[1].Name, "ENV_2")
+	assert.Equal(t, appContainer.Env[1].ValueFrom.SecretKeyRef.Name, "dbsettings")
+	assert.Equal(t, appContainer.Env[1].ValueFrom.SecretKeyRef.Key, "ENV_2")
 }

--- a/test/k8s_service_volume_secret_store_csi_template_test.go
+++ b/test/k8s_service_volume_secret_store_csi_template_test.go
@@ -21,9 +21,9 @@ func TestK8SServiceDeploymentCheckSecretStoreCSIBlock(t *testing.T) {
 		map[string]string{
 			"secrets.dbsettings.as":        "csi",
 			"secrets.dbsettings.mountPath": "/etc/db",
+			"secrets.dbsettings.readOnly":  "true",
 
 			"secrets.dbsettings.csi.driver":              "secrets-store.csi.k8s.io",
-			"secrets.dbsettings.csi.readOnly":            "true",
 			"secrets.dbsettings.csi.secretProviderClass": "secret-provider-class",
 
 			"secrets.dbsettings.items.host.envVarName": "DB_HOST",

--- a/test/k8s_service_volume_secret_store_csi_template_test.go
+++ b/test/k8s_service_volume_secret_store_csi_template_test.go
@@ -7,14 +7,10 @@
 package test
 
 import (
-	// "fmt"
-	// "github.com/gruntwork-io/terratest/modules/random"
+	"testing"
 
-	// "github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	// "strings"
-	"testing"
 )
 
 func TestK8SServiceDeploymentCheckSecretStoreCSIBlock(t *testing.T) {
@@ -23,50 +19,35 @@ func TestK8SServiceDeploymentCheckSecretStoreCSIBlock(t *testing.T) {
 	deployment := renderK8SServiceDeploymentWithSetValues(
 		t,
 		map[string]string{
+			"secrets.dbsettings.as":        "csi",
+			"secrets.dbsettings.mountPath": "/etc/db",
 
-			"serviceAccount.name":   "secret-sa",
-			"secrets.dbsettings.as": "csi",
+			"secrets.dbsettings.csi.driver":              "secrets-store.csi.k8s.io",
+			"secrets.dbsettings.csi.readOnly":            "true",
+			"secrets.dbsettings.csi.secretProviderClass": "secret-provider-class",
 
-			"secrets.dbsettings.mountPath":    "/etc/db",
-			"secrets.dbsettings.csi.driver":   "secrets-store.csi.k8s.io",
-			"secrets.dbsettings.csi.readOnly": "true",
-
-			"secrets.dbsettings.csi.volumeAttributes.secretProviderClass": "secret-provider-class",
-
-			"secrets.dbsettings.items[0].name":                        "ENV_1",
-			"secrets.dbsettings.items[0].valueFrom.secretKeyRef.name": "dbsettings",
-			"secrets.dbsettings.items[0].valueFrom.secretKeyRef.key":  "ENV_1",
-			"secrets.dbsettings.items[1].name":                        "ENV_2",
-			"secrets.dbsettings.items[1].valueFrom.secretKeyRef.name": "dbsettings",
-			"secrets.dbsettings.items[1].valueFrom.secretKeyRef.key":  "ENV_2",
+			"secrets.dbsettings.items.host.envVarName": "DB_HOST",
+			"secrets.dbsettings.items.port.envVarName": "DB_PORT",
 		},
 	)
 
 	// Verify that there is only one container and only one volume
 	renderedPodContainers := deployment.Spec.Template.Spec.Containers
 	require.Equal(t, len(renderedPodContainers), 1)
-	appContainer := renderedPodContainers[0]
 	renderedPodVolumes := deployment.Spec.Template.Spec.Volumes
 	require.Equal(t, len(renderedPodVolumes), 1)
 	podVolume := renderedPodVolumes[0]
 
-	// Check that the pod volume is a secret volume
+	// Check that the pod volume has a correct name
 	assert.Equal(t, podVolume.Name, "dbsettings-volume")
-
+	
 	// Check that the pod volume has CSI block
-	require.NotNil(t, podVolume.CSI)
+	assert.NotNil(t, podVolume.CSI)
+
+	// Check that the pod volume has correct CSI driver and attributes
 	assert.Equal(t, podVolume.CSI.Driver, "secrets-store.csi.k8s.io")
 	assert.NotNil(t, podVolume.CSI.VolumeAttributes)
 	assert.Equal(t, podVolume.CSI.VolumeAttributes, map[string]string{
 		"secretProviderClass": "secret-provider-class",
 	})
-
-	// Check that the container env contains the ENV from secrets
-	require.NotNil(t, appContainer.Env)
-	assert.Equal(t, appContainer.Env[0].Name, "ENV_1")
-	assert.Equal(t, appContainer.Env[0].ValueFrom.SecretKeyRef.Name, "dbsettings")
-	assert.Equal(t, appContainer.Env[0].ValueFrom.SecretKeyRef.Key, "ENV_1")
-	assert.Equal(t, appContainer.Env[1].Name, "ENV_2")
-	assert.Equal(t, appContainer.Env[1].ValueFrom.SecretKeyRef.Name, "dbsettings")
-	assert.Equal(t, appContainer.Env[1].ValueFrom.SecretKeyRef.Key, "ENV_2")
 }

--- a/test/k8s_service_volume_secret_store_csi_template_test.go
+++ b/test/k8s_service_volume_secret_store_csi_template_test.go
@@ -1,0 +1,57 @@
+//go:build all || tpl
+// +build all tpl
+
+// NOTE: We use build flags to differentiate between template tests and integration tests so that you can conveniently
+// run just the template tests. See the test README for more information.
+
+package test
+
+import (
+	// "fmt"
+	// "github.com/gruntwork-io/terratest/modules/random"
+
+	// "github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	// "strings"
+	"testing"
+)
+
+func TestK8SServiceDeploymentCheckSecretStoreCSIBlock(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"secrets.dbsettings.as":           "volume",
+			"secrets.dbsettings.mountPath":    "/etc/db",
+			"secrets.dbsettings.csi.driver":   "secrets-store.csi.k8s.io",
+			"secrets.dbsettings.csi.readOnly": "true",
+
+			"secrets.dbsettings.csi.volumeAttributes.secretProviderClass": "backend-deployment-aws-secrets",
+		},
+	)
+
+	// Verify that there is only one container and only one volume
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	// appContainer := renderedPodContainers[0]
+	renderedPodVolumes := deployment.Spec.Template.Spec.Volumes
+	require.Equal(t, len(renderedPodVolumes), 1)
+	podVolume := renderedPodVolumes[0]
+
+	// Check that the pod volume is a secret volume
+	assert.Equal(t, podVolume.Name, "dbsettings-volume")
+	require.NotNil(t, podVolume.Secret)
+	assert.Equal(t, podVolume.Secret.SecretName, "dbsettings")
+
+	// Check that the pod volume has CSI block
+	require.NotNil(t, podVolume.CSI)
+
+	assert.Equal(t, podVolume.CSI.Driver, "secrets-store.csi.k8s.io")
+	assert.NotNil(t, podVolume.CSI.VolumeAttributes)
+	assert.Equal(t, podVolume.CSI.VolumeAttributes, map[string]string{
+		"secretProviderClass": "backend-deployment-aws-secrets",
+	})
+
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #171 . Can be considered part (subtask) of #118 

In the deployment_spec.tpl we must allow a new "**as**" value to be passed to a secret block, we call this new type "csi".

Receiving this type of a secret, the tpl has to mix functionality of both volumes and environment types, as we will require a env block and a volumeMounts block

## Steps

- [x] add template test - to check a csi block is passed to the secret
- [x] modify deployment_spec.tpl so that it can accept  "csi" for the values of the "as"  and test the template builds appropriately 

## Release Notes (draft)

## TODOs

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes.

## Release Notes

Allow secret of type csi, inject Secret Store CSI related fields to deployment spec Env and Volumes

