### PR TITLE
add support for dnsPolicy

### DIFF
--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -145,6 +145,10 @@ spec:
 {{ toYaml .Values.hostAliases | indent 8 }}
       {{- end }}
 
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
+
       containers:
         {{- if .isCanary }}
         - name: {{ .Values.applicationName }}-canary

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -76,6 +76,14 @@ containerPorts:
     port: 80
     protocol: TCP
 
+# dnsPolicy sets the Pod DNS policy. Allowed values are "Default", "ClusterFirst", "ClusterFirstWithHostNet" (not supported on Windows), 
+# and "None". Note that "Default" is not the default DNS policy. If dnsPolicy is not explicitly specified, then "ClusterFirst" is used.
+# See [Pod's DNS Policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for details.
+#
+# EXAMPLE:
+#
+# dnsPolicy: "ClusterFirst"
+
 # startupProbe is a map that specifies the startup probe of the main application container. Startup probes indicate
 # when a container application has started. If such a probe is configured, it disables liveness and readiness checks
 # until it succeeds, making sure those probes don't interfere with the application startup. This can be used to adopt


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds support for dnsPolicy. Fixes #173.

dnsPolicy has been added to the values.yaml file under Optional Values. If set, it will add it to the deployment spec section.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Added dnsPolicy to the values.yaml. If present it will get added to the deployment spec section.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
