### PR TITLE
Do not set deployment replica count if HPA enabled

### DIFF
--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -96,7 +96,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+{{- if not .Values.horizontalPodAutoscaler.enabled }}
   replicas: {{ if .isCanary }}{{ .Values.canary.replicaCount | default 1 }}{{ else }}{{ .Values.replicaCount }}{{ end }}
+{{- end }}
 {{- if .Values.deploymentStrategy.enabled }}
   strategy:
     type: {{ .Values.deploymentStrategy.type }}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Do not set the number of replicas if the horizontal pod autoscaler(HPA) is enabled. This will avoid conflicts between helm deployment and the HPA.

Warning: on upgrade to this chart version, the number of pod replicas ->1 -> `minReplicas` set in the HPA section of `values.yaml`

This has been tested using `k8s-service-nginx` example.  
1. With Initial conditions: 
```yaml
replicaCount: 3
horizontalPodAutoscaler:
  enabled: false
  minReplicas: 2
  maxReplicas: 5
```
the pod count is `3`.  

2. Turn on HPA: 
```yaml
replicaCount: 3
horizontalPodAutoscaler:
  enabled: true
  minReplicas: 2
  maxReplicas: 5
```
and do `helm upgrade` and the pod count changes to `2`

3. Apply change and run `helm upgrade` the pod replica count goes down to `1` temporarily before reverting `2`
4. Change replicaCount to `4` and do helm upgrade
```yaml
replicaCount: 4
horizontalPodAutoscaler:
  enabled: true
  minReplicas: 2
  maxReplicas: 5
```
and pod count remains at `2`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Do not set deployment replica count if HPA enabled

### Migration Guide



<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
