### PR TITLE
[WIP]Add ArgoCD Application Helm Chart

### DIFF
--- a/charts/argocd-application/Chart.yaml
+++ b/charts/argocd-application/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: argocd-application
+description: Wrapper Chart for an Argo CD Application CRD
+type: application
+version: 0.1.0
+home: https://github.com/gruntwork-io/helm-kubernetes-services
+maintainers:
+  - name: Gruntwork
+    email: info@gruntwork.io
+    url: https://gruntwork.io

--- a/charts/argocd-application/README.md
+++ b/charts/argocd-application/README.md
@@ -1,0 +1,3 @@
+# ArgoCD Application Helm Chart
+This Helm chart can be used to deploy an ArgoCD [Application CRD](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#applications). The ArgoCD Application CRD is the Kubernetes resource object representing a deployed application instance in an environment. For detailed information about the ArgoCD Application CRD, please see the [official documentation](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#applications).
+

--- a/charts/argocd-application/templates/application.yaml
+++ b/charts/argocd-application/templates/application.yaml
@@ -1,0 +1,164 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.applicationName }}
+  namespace: {{ .Values.argoNamespace }}
+  {{- if .Values.finalizers }}
+  finalizers:
+{{ tpl .Values.finalizers $ | indent 4 }}
+{{- end }}
+  {{- if .Values.labels }}
+  labels:
+{{ tpl .Values.labels $ | indent 4 }}
+{{- end }}
+spec:
+  project: {{ .Values.project }}
+  destination:
+    namespace: {{ .Values.destination.namespace }}
+    {{- if .Values.destination.clusterName }}
+    name: {{ .Values.destination.clusterName }}
+    {{- else }}
+    server: {{ .Values.destination.clusterServer }}
+    {{- end }}
+  source:
+    repoURL: {{ .Values.source.repoURL }}
+    targetRevision: {{ .Values.source.targetRevision }}
+    path: {{ .Values.source.path }}
+    {{- if .Values.source.chart }}
+    chart: {{ .Values.source.chart }}
+    {{- end }}
+    # HELM
+    {{- if .Values.source.helm }}
+    helm:
+      passCredentials: {{ .Values.source.helm.passCredentials }}
+      {{- if .Values.source.helm.parameters }}
+      parameters:
+{{ tpl .Values.source.helm.parameters $ | indent 6 }}
+      {{- end }}
+      {{- if .Values.source.helm.fileParameters }}
+      fileParameters:
+{{ tpl .Values.source.helm.fileParameters $ | indent 6 }}
+      {{- end }}
+      {{- if .Values.source.helm.releaseName }}
+      releaseName: {{ .Values.source.helm.releaseName }}
+      {{- end }}
+      {{- if .Values.source.helm.valueFiles }}
+      valueFiles:
+{{ tpl .Values.source.helm.valueFiles $ | indent 6 }}
+      {{- end }}
+      ignoreMissingValueFiles: {{ .Values.source.helm.ignoreMissingValueFiles }}
+      {{- if .Values.source.helm.valuesBlockFile }}
+{{ tpl .Values.source.helm.valuesBlockFile $ | indent 6 }}
+      {{- end }}
+      {{- if .Values.source.helm.valuesBlockObject }}
+{{ tpl .Values.source.helm.valuesBlockObject $ | indent 6 }}
+      {{- end }}
+      skipCrds: {{ .Values.source.helm.skipCrds }}
+      {{- if .Values.source.helm.version }}
+      version: {{ .Values.source.helm.version }}
+      {{- end }}
+    {{- end }}
+    # KUSTOMIZE
+    {{- if .Values.source.kustomize }}
+    kustomize:
+      {{- if .Values.source.kustomize.version }}
+      version: {{ .Values.source.kustomize.version }}
+      {{- end }}
+      {{- if .Values.source.kustomize.namePrefix }}
+      namePrefix: {{ .Values.source.kustomize.namePrefix }}
+      {{- end }}
+      {{- if .Values.source.kustomize.nameSuffix }}
+      nameSuffix: {{ .Values.source.kustomize.nameSuffix }}
+      {{- end }}
+      {{- if .Values.source.kustomize.commonLabels }}
+      commonLabels: 
+{{ tpl .Values.source.kustomize.commonLabels $ | indent 6 }}
+      {{- end }}
+      {{- if .Values.source.kustomize.commonAnnotations }}
+      commonAnnotations: 
+{{ tpl .Values.source.kustomize.commonAnnotations $ | indent 6 }}
+      {{- end }}
+      {{- if .Values.source.kustomize.commonAnnotationsEnvsubst }}
+      commonAnnotationsEnvsubst: {{ .Values.source.kustomize.commonAnnotationsEnvsubst }}
+      {{- end }}
+      {{- if .Values.source.kustomize.images }}
+      images: 
+{{ tpl .Values.source.kustomize.images $ | indent 6 }}
+      {{- end }}
+      {{- if .Values.source.kustomize.namespace }}
+      namespace: {{ .Values.source.kustomize.namespace }}
+      {{- end }}
+      {{- if .Values.source.kustomize.replicas }}
+      replicas: 
+{{ tpl .Values.source.kustomize.replicas $ | indent 6 }}
+      {{- end }}
+    {{- end }}
+
+    # DIRECTORY
+    {{- if .Values.source.directory }}
+    directory:
+      {{- if .Values.source.directory.recurse }}
+      recurse: {{ .Values.source.directory.recurse }}
+      {{- end }}
+      {{- if .Values.source.directory.jsonnet }}
+      jsonnet: 
+{{ tpl .Values.source.directory.jsonnet $ | indent 6 }}
+      {{- end }}
+      {{- if .Values.source.directory.exclude }}
+      exclude: {{ .Values.source.directory.exclude }}
+      {{- end }}
+      {{- if .Values.source.directory.include }}
+      include: {{ .Values.source.directory.include }}
+      {{- end }}
+    {{- end }}
+  # SOURCES
+  {{- if .Values.sources }}
+  sources: 
+{{ tpl .Values.sources $ | indent 2 }}
+  {{- end }}
+  {{- if .Values.info }}
+  info: 
+{{ tpl .Values.info $ | indent 2 }}
+  {{- end }}
+  # Sync policy
+  syncPolicy:
+    automated:
+      prune: {{ .Values.syncPolicy.prune | default true }}
+      selfHeal: {{ .Values.syncPolicy.selfHeal | default true }}
+      allowEmpty: {{ .Values.syncPolicy.allowEmpty | default false }}
+    {{- if .Values.syncPolicy.syncOptions }}
+    syncOptions:
+    {{- range .Values.syncPolicy.syncOptions }}
+    - {{ . }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.syncPolicy.managedNamespaceMetadata }}
+    managedNamespaceMetadata:
+    {{- end }}
+    {{- if (and .Values.syncPolicy.managedNamespaceMetadata .Values.syncPolicy.managedNamespaceMetadata.labels) }}
+      labels:
+      {{- range $k, $v := .Values.syncPolicy.managedNamespaceMetadata.labels }}
+        {{ $k }}: {{ $v }}
+      {{- end }}
+    {{- end }}
+    {{- if (and .Values.syncPolicy.managedNamespaceMetadata .Values.syncPolicy.managedNamespaceMetadata.annotations) }}
+      annotations:
+      {{- range $k, $v := .Values.syncPolicy.managedNamespaceMetadata.annotations }}
+        {{ $k }}: {{ $v }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.syncPolicy.retry }}
+    retry:
+      limit: {{ .Values.syncPolicy.retry.limit | default 5 }}
+      {{- if .Values.syncPolicy.retry.backoff }}
+      backoff:
+        duration: {{ .Values.syncPolicy.retry.backoff.duration }}
+        factor: {{ .Values.syncPolicy.retry.backoff.factor }}
+        maxDuration: {{ .Values.syncPolicy.retry.backoff.maxDuration }}
+      {{- end }}
+    {{- end }}
+  {{- if .Values.ignoreDifferences }}
+  ignoreDifferences:
+{{ tpl .Values.ignoreDifferences $ | indent 2 }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default 10 }}

--- a/charts/argocd-application/values.yaml
+++ b/charts/argocd-application/values.yaml
@@ -1,0 +1,59 @@
+# 
+applicationName: "test-app"
+argoNamespace: "argocd"
+finalizers:
+- resources-finalizer.argocd.argoproj.io
+labels:
+project: "default"
+destination:
+  clusterName:
+  clusterServer: "https://kubernetes.default.svc"
+source:
+  repoURL:
+  targetRevision:
+  path:
+  chart:
+  helm:
+    passCredentials: false
+    parameters:
+    fileParameters:
+    releaseName:
+    valueFiles:
+    ignoreMissingValueFiles: false 
+    valuesBlockFile:
+    valuesBlockObject:
+    skipCrds: false
+    version: 
+  kustomize:
+    version:
+    namePrefix:
+    nameSuffix:
+    commonLabels:
+    commonAnnotations:
+    commonAnnotationsEnvsubst:
+    images:
+    namespace:
+    replicas:
+  directory:
+    recurse:
+    jsonnet:
+    exclude:
+    include:
+sources:
+info:
+syncPolicy:
+  prune:
+  selfHeal:
+  allowEmpty:
+  syncOptions:
+  managedNamespaceMetadata:
+    labels:
+    annotations:
+  retry:
+    limit:
+    backoff:
+      duration:
+      factor:
+      maxDuration:
+ignoreDifferences:
+revisionHistoryLimit: 10


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This PR adds a new Helm chart to the `helm-kubernetes-services` repository. The new chart is an Argo CD Application wrapped as a Helm chart. This provides the ability to deploy ArgoCD Application CRDs as Helm charts.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
- Added new Helm chart `argocd-application`

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
