### PR TITLE
Avoid setting replicase while HPA is enabled

### DIFF
--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -96,7 +96,13 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: {{ if .isCanary }}{{ .Values.canary.replicaCount | default 1 }}{{ else }}{{ .Values.replicaCount }}{{ end }}
+{{- if .isCanary }}
+  replicas: {{ .Values.canary.replicaCount | default 1 }}
+{{ else }}
+{{- if not .Values.horizontalPodAutoscaler.enabled }} 
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+{{- end }}
 {{- if .Values.deploymentStrategy.enabled }}
   strategy:
     type: {{ .Values.deploymentStrategy.type }}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Setting a replica number if HPA is used can cause outages (if `replicas is 0`) or degraded performance if `replicas < minReplicas`

One thing to note: The canary deployment is not targeted by the HPA:
* The name of the canary has `-canary` at the end see [code](https://github.com/gruntwork-io/helm-kubernetes-services/blob/main/charts/k8s-service/templates/_deployment_spec.tpl#L83)
* The HPA target focuses on the main deployment only [see code ](https://github.com/gruntwork-io/helm-kubernetes-services/blob/main/charts/k8s-service/templates/horizontalpodautoscaler.yaml#L11)

So we need to avoid the `replicas` only if the deployment is not a canary.

Fixes #180.


## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- ~[] Update the docs.~
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Ignore `replicaCount` when HPA is enabled to avoid drastic fluctuations during releases.

### Migration Guide

\-