### PR TITLE
fix: additional pod/deployment labeling bool string encapsulation

### DIFF
--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -89,7 +89,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- range $key, $value := .Values.additionalDeploymentLabels }}
-    {{ $key }}: {{ $value }}
+    {{ $key }}: "{{ $value }}"
     {{- end}}
 {{- with .Values.deploymentAnnotations }}
   annotations:
@@ -131,7 +131,7 @@ spec:
         gruntwork.io/deployment-type: main
         {{- end }}
         {{- range $key, $value := .Values.additionalPodLabels }}
-        {{ $key }}: {{ $value }}
+        {{ $key }}: "{{ $value }}"
         {{- end }}
 
       {{- with .Values.podAnnotations }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -334,11 +334,11 @@ additionalDeploymentLabels: {}
 # NOTE: This variable is injected directly into the pod spec.
 podAnnotations: {}
 
-# additionalDeploymentLabels will add the provided map to the labels for the Pods created by the deployment resource.
+# additionalPodLabels will add the provided map to the labels for the Pods created by the deployment resource.
 # this is in addition to the helm template related labels created by the chart
 # The keys and values are free form, but subject to the limitations of Kubernetes labelling.
 # The match labels for the deployment aren't affected by these additional labels
-# NOTE: This variable is injected directly into the deployment spec.
+# NOTE: This variable is injected directly into the pod spec.
 additionalPodLabels: {}
 
 # minPodsAvailable specifies the minimum number of pods that should be available at any given point in time. This is


### PR DESCRIPTION
## Description

Fixes #74 when deploying via ArgoCD, which surfaces this issue with string encapsulation of boolean values for labels: https://github.com/argoproj/argo-cd/issues/4391

This shouldn't create any backwards compatibility issues.