### PR TITLE
Add support for pod topologySpreadConstraints

### DIFF
--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -461,6 +461,11 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
 
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+
     {{- with .Values.priorityClassName }}
       priorityClassName:
 {{ toYaml . | indent 8 }}

--- a/charts/k8s-service/values.yaml
+++ b/charts/k8s-service/values.yaml
@@ -682,11 +682,12 @@ secrets: {}
 # like: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 containerResources: {}
 
-# nodeSelector and affinity specify restrictions on what node this pod should be scheduled on.
+# nodeSelector, affinity and topologySpreadConstraints specify restrictions on what node this pod should be scheduled on.
 # NOTE: These variables are injected directly into the pod spec. See the official documentation for what this might look
 # like: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 nodeSelector: {}
 affinity: {}
+topologySpreadConstraints: []
 
 # priorityClassName assigns a priorityClass to the deployment allowing pods to preempt or be preempted.
 # See https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
## Description

Fixes #200 by adding support for [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) in the pod spec.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added support for pod topology spread constraints